### PR TITLE
Found an error in the truth table for logical implication

### DIFF
--- a/src/test/scala/s99/LogicAndCodesProblems.scala
+++ b/src/test/scala/s99/LogicAndCodesProblems.scala
@@ -45,7 +45,7 @@ trait LogicAndCodesProblems extends Specification with DataTables with ThrownExp
      T  ! T   ! T            |
      T  ! F   ! F            |
      F  ! T   ! T            |
-     F  ! F   ! F            | { impl(_, _) === _ }
+     F  ! F   ! T            | { impl(_, _) === _ }
 
     "a" | "b" | "equ(a, b)" |>
      T  ! T   ! T           |


### PR DESCRIPTION
Fixed truth table for impl(). Logical implication is false if _and only if_ the first argument is T and the second is F.

Ref: http://simple.wikipedia.org/wiki/Implication_%28logic%29

Thanks for this awesome learning tool! :)
