### PR TITLE
More examples in specs (and update to Scala 2.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
-This project is the implementation of the [99 Scala problems](http://aperiodic.net/phil/scala/s-99/) as a set of [specs2](http://specs2.org) specifications, ready to implement and execute with [sbt](https://github.com/harrah/xsbt/).
+S-99: Ninety-Nine Scala Problems
+====
 
-Each Specification is divided into:
+My implementation of the [99 Scala problems](http://aperiodic.net/phil/scala/s-99/), accompanied by [specs2](http://specs2.org) specifications (using [these](https://github.com/etorreborre/s99) as a start) and ready to run with [sbt](https://github.com/harrah/xsbt/).
 
- - the description of the problem to solve (see [`ListsSpec`](https://github.com/etorreborre/s99/blob/master/src/test/scala/s99/ListsSpec.scala) for an example)
- - the methods to implement (see [`ListsSolutions`](https://github.com/etorreborre/s99/blob/master/src/main/scala/s99/ListsSolutions.scala) for an example)
-
-To run the specifications, install sbt (version > 0.11.2) and execute:
-
-sbt>test
-
-To see only the failed ones:
-
-sbt>test-only -- xonly
-
-*WARNING* The specifications have not yet been all tested against a valid implementation, please report any bug!
-
+The coverage of the specs is continuously being increased as I am solving the problems, in order for me to test all relevant corner cases (at least the ones I can remember). People who want to solve these problems and want a fresh code base with tests can fork the branch `specs-only`.

--- a/build.sbt
+++ b/build.sbt
@@ -8,4 +8,4 @@ scalaVersion := "2.11.6"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.6"
 
-scalacOptions ++= Seq("-deprecation", "-unchecked")
+scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions")

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,11 @@
-/** Project */
 name := "s99"
 
-version := "1.0"
+version := "0.1-SNAPSHOT"
 
-organization := "org.specs2"
+organization := "net.ruippeixotog"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.6"
 
-/** Dependencies */
-resolvers ++= Seq(
-  "snapshots-repo" at "http://oss.sonatype.org/content/repositories/snapshots",
-  "releases-repo" at "http://oss.sonatype.org/content/repositories/releases")
-
-libraryDependencies ++= Seq(
-  "org.scalacheck" %% "scalacheck" % "1.10.0", 
-  "org.scala-tools.testing" % "test-interface" % "0.5", 
-  "org.specs2" %% "scalaz-core" % "7.0.0",
-  "org.specs2" %% "specs2" % "1.13",
-  "org.pegdown" % "pegdown" % "1.2.1"
-)
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.6"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")
-
-/** Console */
-initialCommands in console := "import org.specs2._"
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,9 @@
 name := "s99"
-
+organization := "net.ruippeixotog"
 version := "0.1-SNAPSHOT"
 
-organization := "net.ruippeixotog"
+scalaVersion := "2.12.1"
 
-scalaVersion := "2.11.6"
-
-libraryDependencies += "org.specs2" %% "specs2-core" % "3.6"
+libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.7" % "test"
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions")

--- a/build.sbt
+++ b/build.sbt
@@ -5,17 +5,19 @@ version := "1.0"
 
 organization := "org.specs2"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.10.0"
 
 /** Dependencies */
-resolvers ++= Seq("snapshots-repo" at "http://oss.sonatype.org/content/repositories/snapshots")
+resolvers ++= Seq(
+  "snapshots-repo" at "http://oss.sonatype.org/content/repositories/snapshots",
+  "releases-repo" at "http://oss.sonatype.org/content/repositories/releases")
 
 libraryDependencies ++= Seq(
-  "org.scala-tools.testing" %% "scalacheck" % "1.9", 
+  "org.scalacheck" %% "scalacheck" % "1.10.0", 
   "org.scala-tools.testing" % "test-interface" % "0.5", 
-  "org.specs2" %% "specs2-scalaz-core" % "6.0.1",
-  "org.specs2" %% "specs2" % "1.9-SNAPSHOT",
-  "org.pegdown" % "pegdown" % "1.0.2"
+  "org.specs2" %% "scalaz-core" % "7.0.0",
+  "org.specs2" %% "specs2" % "1.13",
+  "org.pegdown" % "pegdown" % "1.2.1"
 )
 
 scalacOptions ++= Seq("-deprecation", "-unchecked")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,0 @@
-resolvers += "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")

--- a/src/main/scala/s99/ArithmeticSolutions.scala
+++ b/src/main/scala/s99/ArithmeticSolutions.scala
@@ -1,14 +1,11 @@
 package s99
 
-import Solutions.???
+import Solutions._
 
 trait ArithmeticSolutions {
 
   // add new functions to integers
-  implicit def extendInt(n: Int): ExtendedInt = ExtendedInt(n)
-
-  case class ExtendedInt(n: Int) {
-
+  implicit class ExtendedInt(n: Int) {
     def isPrime: Boolean = ???
     def isCoprimeTo(n: Int): Boolean = ???
     def totient: Int = ???
@@ -18,7 +15,6 @@ trait ArithmeticSolutions {
     def improvedTotient: Int = ???
     def listPrimesinRange(r: Range): List[Int] = ???
     def goldbach: (Int, Int) = ???
-
   }
 
   def gcd(m: Int, n: Int): Int = ???
@@ -28,5 +24,4 @@ trait ArithmeticSolutions {
 
   // Optional but possibly useful exercise: not in original s-99 problems
   def primes: Stream[Int] = ???
-
 }

--- a/src/main/scala/s99/ArithmeticSolutions.scala
+++ b/src/main/scala/s99/ArithmeticSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions._
-
 trait ArithmeticSolutions {
 
   // add new functions to integers

--- a/src/main/scala/s99/ArithmeticSolutions.scala
+++ b/src/main/scala/s99/ArithmeticSolutions.scala
@@ -12,19 +12,21 @@ trait ArithmeticSolutions {
     def isPrime: Boolean = ???
     def isCoprimeTo(n: Int): Boolean = ???
     def totient: Int = ???
-    def improvedTotient: Int = ???
     def primeFactors: List[Int] = ???
     def primeFactorMultiplicity: List[(Int, Int)] = ???
     def primeFactorMultiplicityMap: Map[Int, Int] = ???
+    def improvedTotient: Int = ???
     def listPrimesinRange(r: Range): List[Int] = ???
     def goldbach: (Int, Int) = ???
 
   }
 
-  def primes: Stream[Int] = ???
   def gcd(m: Int, n: Int): Int = ???
   def listPrimesinRange(r: Range): List[Int] = ???
   def printGoldbachList(r: Range): List[String] = ???
   def printGoldbachListLimited(r: Range, limit: Int): List[String] = ???
+
+  // Optional but possibly useful exercise: not in original s-99 problems
+  def primes: Stream[Int] = ???
 
 }

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -5,8 +5,14 @@ import Solutions.???
 trait BinaryTreesSolutions {
 
   sealed abstract class Tree[+T] {
-    def addValue[S >: T](s: S): Tree[S] = ???
     def isSymmetric: Boolean = ???
+    def addValue[S >: T <% Ordered[S]](s: S): Tree[S] = ???
+
+    def leafCount: Int = ???
+    def leafList: List[T] = ???
+    def internalList: List[T] = ???
+    def atLevel(n: Int): List[T] = ???
+
     def preOrder: List[T] = ???
     def inOrder: List[T] = ???
     def toDotString: String = ???
@@ -15,10 +21,6 @@ trait BinaryTreesSolutions {
   case class Node[+T](value: T, left: Tree[T], right: Tree[T]) extends Tree[T] {
     override def toString = "T(" + value.toString + " " + left.toString + " " + right.toString + ")"
 
-    def leafCount: Int = ???
-    def leafList: List[T] = ???
-    def internalList: List[T] = ???
-    def atLevel(n: Int): List[T] = ???
     def layoutBinaryTree: PositionedNode[T] = ???
     def layoutBinaryTree2: PositionedNode[T] = ???
     def layoutBinaryTree3: PositionedNode[T] = ???
@@ -36,15 +38,15 @@ trait BinaryTreesSolutions {
 
   object Tree {
 
-    def cBalanced(n: Int,  s: String): List[Node[String]] = ???
-    def fromList(list: List[Int]): Tree[Int] = ???
-    def symmetricBalancedTrees(n: Int,  s: String): List[Node[String]] = ???
-    def hbalTrees(n: Int,  s: String): List[Node[String]] = ???
+    def cBalanced[T](n: Int, e: T): List[Tree[T]] = ???
+    def fromList[T <% Ordered[T]](list: List[T]): Tree[T] = ???
+    def symmetricBalancedTrees[T](n: Int, e: T): List[Tree[T]] = ???
+    def hbalTrees[T](h: Int, e: T): List[Tree[T]] = ???
 
-    def minHbalNodes(n: Int): Int = ???
+    def minHbalNodes(h: Int): Int = ???
     def maxHbalHeight(n: Int): Int = ???
-    def hbalTreesWithNodes(n: Int,  s: String): List[Node[String]] = ???
-    def completeBinaryTree(n: Int,  s: String): List[Node[String]] = ???
+    def hbalTreesWithNodes[T](n: Int, e: T): List[Tree[T]] = ???
+    def completeBinaryTree[T](n: Int, e: T): List[Tree[T]] = ???
 
     def fromString(string: String): Node[Char] = ???
     def fromDotString(string: String): Node[Char] = ???

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -13,6 +13,10 @@ trait BinaryTreesSolutions {
     def internalList: List[T] = ???
     def atLevel(n: Int): List[T] = ???
 
+    def layoutBinaryTree: Tree[T] = ???
+    def layoutBinaryTree2: Tree[T] = ???
+    def layoutBinaryTree3: Tree[T] = ???
+
     def preOrder: List[T] = ???
     def inOrder: List[T] = ???
     def toDotString: String = ???
@@ -20,10 +24,6 @@ trait BinaryTreesSolutions {
 
   case class Node[+T](value: T, left: Tree[T], right: Tree[T]) extends Tree[T] {
     override def toString = "T(" + value.toString + " " + left.toString + " " + right.toString + ")"
-
-    def layoutBinaryTree: PositionedNode[T] = ???
-    def layoutBinaryTree2: PositionedNode[T] = ???
-    def layoutBinaryTree3: PositionedNode[T] = ???
 
     def show: String = ???
   }

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions.???
-
 trait BinaryTreesSolutions {
 
   sealed abstract class Tree[+T] {

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -58,9 +58,17 @@ trait BinaryTreesSolutions {
 
   class PositionedNode[+T](override val value: T,
                            override val left: Tree[T],
-                           override val right: Tree[T], x: Int, y: Int) extends Node[T](value, left, right) {
+                           override val right: Tree[T],
+                           val x: Int,
+                           val y: Int) extends Node[T](value, left, right) {
     override def toString = "T[" + x.toString + "," + y.toString + "](" +
       value.toString + " " + left.toString + " " + right.toString + ")"
   }
 
+  object PositionedNode {
+    def apply[T](value: T, left: Tree[T], right: Tree[T], x: Int, y: Int) =
+      new PositionedNode[T](value, left, right, x, y)
+    def unapply[T](p: PositionedNode[T]) =
+      Some((p.value, p.left, p.right, p.x, p.y))
+  }
 }

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -6,7 +6,7 @@ trait BinaryTreesSolutions {
 
   sealed abstract class Tree[+T] {
     def isSymmetric: Boolean = ???
-    def addValue[S >: T <% Ordered[S]](s: S): Tree[S] = ???
+    def addValue[S >: T: Ordering](s: S): Tree[S] = ???
 
     def leafCount: Int = ???
     def leafList: List[T] = ???
@@ -24,7 +24,7 @@ trait BinaryTreesSolutions {
   }
 
   case class Node[+T](value: T, left: Tree[T], right: Tree[T]) extends Tree[T] {
-    override def toString = "T(" + value.toString + " " + left.toString + " " + right.toString + ")"
+    override def toString = s"T($value $left $right)"
   }
 
   case object End extends Tree[Nothing] {
@@ -36,9 +36,8 @@ trait BinaryTreesSolutions {
   }
 
   object Tree {
-
     def cBalanced[T](n: Int, e: T): List[Tree[T]] = ???
-    def fromList[T <% Ordered[T]](list: List[T]): Tree[T] = ???
+    def fromList[T: Ordering](list: List[T]): Tree[T] = ???
     def symmetricBalancedTrees[T](n: Int, e: T): List[Tree[T]] = ???
     def hbalTrees[T](h: Int, e: T): List[Tree[T]] = ???
 
@@ -57,8 +56,7 @@ trait BinaryTreesSolutions {
                            override val right: Tree[T],
                            val x: Int,
                            val y: Int) extends Node[T](value, left, right) {
-    override def toString = "T[" + x.toString + "," + y.toString + "](" +
-      value.toString + " " + left.toString + " " + right.toString + ")"
+    override def toString = s"T[$x, $y]($value $left $right)"
   }
 
   object PositionedNode {

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -46,7 +46,7 @@ trait BinaryTreesSolutions {
     def minHbalNodes(h: Int): Int = ???
     def maxHbalHeight(n: Int): Int = ???
     def hbalTreesWithNodes[T](n: Int, e: T): List[Tree[T]] = ???
-    def completeBinaryTree[T](n: Int, e: T): List[Tree[T]] = ???
+    def completeBinaryTree[T](n: Int, e: T): Tree[T] = ???
 
     def fromString(string: String): Node[Char] = ???
     def fromDotString(string: String): Node[Char] = ???

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -56,7 +56,7 @@ trait BinaryTreesSolutions {
                            override val right: Tree[T],
                            val x: Int,
                            val y: Int) extends Node[T](value, left, right) {
-    override def toString = s"T[$x, $y]($value $left $right)"
+    override def toString = s"T[$x,$y]($value $left $right)"
   }
 
   object PositionedNode {

--- a/src/main/scala/s99/BinaryTreesSolutions.scala
+++ b/src/main/scala/s99/BinaryTreesSolutions.scala
@@ -17,6 +17,7 @@ trait BinaryTreesSolutions {
     def layoutBinaryTree2: Tree[T] = ???
     def layoutBinaryTree3: Tree[T] = ???
 
+    def show: String = ???
     def preOrder: List[T] = ???
     def inOrder: List[T] = ???
     def toDotString: String = ???
@@ -24,8 +25,6 @@ trait BinaryTreesSolutions {
 
   case class Node[+T](value: T, left: Tree[T], right: Tree[T]) extends Tree[T] {
     override def toString = "T(" + value.toString + " " + left.toString + " " + right.toString + ")"
-
-    def show: String = ???
   }
 
   case object End extends Tree[Nothing] {
@@ -48,12 +47,9 @@ trait BinaryTreesSolutions {
     def hbalTreesWithNodes[T](n: Int, e: T): List[Tree[T]] = ???
     def completeBinaryTree[T](n: Int, e: T): Tree[T] = ???
 
-    def fromString(string: String): Node[Char] = ???
-    def fromDotString(string: String): Node[Char] = ???
-
-    def string2Tree(string: String): Tree[Char] = ???
-
-    def preInTree(lists: List[Char]*): Node[Char] = ???
+    def fromString(string: String): Tree[Char] = ???
+    def preInTree[T](pre: List[T], in: List[T]): Tree[T] = ???
+    def fromDotString(string: String): Tree[Char] = ???
   }
 
   class PositionedNode[+T](override val value: T,

--- a/src/main/scala/s99/GraphsSolutions.scala
+++ b/src/main/scala/s99/GraphsSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions._
-
 trait GraphsSolutions {
 
   object Graph {

--- a/src/main/scala/s99/ListsSolutions.scala
+++ b/src/main/scala/s99/ListsSolutions.scala
@@ -3,7 +3,6 @@ package s99
 import Solutions._
 
 trait ListsSolutions {
-
   def last[T](list: List[T]): T = ???
   def penultimate[T](list: List[T]): T = ???
   def nth[T](n: Int, list: List[T]): T = ???
@@ -34,6 +33,4 @@ trait ListsSolutions {
   def groups[T](ns: List[Int], list: List[T]): List[List[List[T]]] = ???
   def lsort[T](list: List[List[T]]): List[List[T]] = ???
   def lsortFreq[T](list: List[List[T]]): List[List[T]] = ???
-
 }
-

--- a/src/main/scala/s99/ListsSolutions.scala
+++ b/src/main/scala/s99/ListsSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions._
-
 trait ListsSolutions {
   def last[T](list: List[T]): T = ???
   def penultimate[T](list: List[T]): T = ???

--- a/src/main/scala/s99/LogicAndCodesSolutions.scala
+++ b/src/main/scala/s99/LogicAndCodesSolutions.scala
@@ -7,7 +7,7 @@ trait LogicAndCodesSolutions { outer =>
   implicit def extendBoolean(a: Boolean): ExtendedBoolean = ExtendedBoolean(a)
   case class ExtendedBoolean(a: Boolean) {
     def and (b: =>Boolean): Boolean = outer.and (a, b)
-    def or  (b: =>Boolean): Boolean = outer.or  (a, b) 
+    def or  (b: =>Boolean): Boolean = outer.or  (a, b)
     def nand(b: =>Boolean): Boolean = outer.nand(a, b)
     def nor (b: =>Boolean): Boolean = outer.nor (a, b)
     def xor (b: =>Boolean): Boolean = outer.xor (a, b)
@@ -23,8 +23,8 @@ trait LogicAndCodesSolutions { outer =>
   def xor(a: Boolean,  b: =>Boolean): Boolean = ???
   def impl(a: Boolean,  b: =>Boolean): Boolean = ???
   def equ(a: Boolean,  b: =>Boolean): Boolean = ???
-  def not(a: Boolean) = ???
-  
+  def not(a: Boolean): Boolean = ???
+
   def table2(f: (Boolean, Boolean) => Boolean): String = ???
 
   def gray(n: Int): List[String] = ???

--- a/src/main/scala/s99/LogicAndCodesSolutions.scala
+++ b/src/main/scala/s99/LogicAndCodesSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions._
-
 trait LogicAndCodesSolutions { outer =>
 
   implicit class ExtendedBoolean(a: Boolean) {

--- a/src/main/scala/s99/LogicAndCodesSolutions.scala
+++ b/src/main/scala/s99/LogicAndCodesSolutions.scala
@@ -1,33 +1,30 @@
 package s99
 
-import Solutions.???
+import Solutions._
 
 trait LogicAndCodesSolutions { outer =>
 
-  implicit def extendBoolean(a: Boolean): ExtendedBoolean = ExtendedBoolean(a)
-  case class ExtendedBoolean(a: Boolean) {
-    def and (b: =>Boolean): Boolean = outer.and (a, b)
-    def or  (b: =>Boolean): Boolean = outer.or  (a, b)
-    def nand(b: =>Boolean): Boolean = outer.nand(a, b)
-    def nor (b: =>Boolean): Boolean = outer.nor (a, b)
-    def xor (b: =>Boolean): Boolean = outer.xor (a, b)
-    def impl(b: =>Boolean): Boolean = outer.impl(a, b)
-    def equ (b: =>Boolean): Boolean = outer.equ (a, b)
-
+  implicit class ExtendedBoolean(a: Boolean) {
+    def and(b: => Boolean): Boolean = outer.and(a, b)
+    def or(b: => Boolean): Boolean = outer.or(a, b)
+    def nand(b: => Boolean): Boolean = outer.nand(a, b)
+    def nor(b: => Boolean): Boolean = outer.nor(a, b)
+    def xor(b: => Boolean): Boolean = outer.xor(a, b)
+    def impl(b: => Boolean): Boolean = outer.impl(a, b)
+    def equ(b: => Boolean): Boolean = outer.equ(a, b)
   }
   
-  def and(a: Boolean,  b: =>Boolean): Boolean = ???
-  def or(a: Boolean,   b: =>Boolean): Boolean = ???
-  def nand(a: Boolean,  b: =>Boolean): Boolean = ???
-  def nor(a: Boolean,  b: =>Boolean): Boolean = ???
-  def xor(a: Boolean,  b: =>Boolean): Boolean = ???
-  def impl(a: Boolean,  b: =>Boolean): Boolean = ???
-  def equ(a: Boolean,  b: =>Boolean): Boolean = ???
+  def and(a: Boolean, b: => Boolean): Boolean = ???
+  def or(a: Boolean, b: => Boolean): Boolean = ???
+  def nand(a: Boolean, b: => Boolean): Boolean = ???
+  def nor(a: Boolean, b: => Boolean): Boolean = ???
+  def xor(a: Boolean, b: => Boolean): Boolean = ???
+  def impl(a: Boolean, b: => Boolean): Boolean = ???
+  def equ(a: Boolean, b: => Boolean): Boolean = ???
   def not(a: Boolean): Boolean = ???
 
   def table2(f: (Boolean, Boolean) => Boolean): String = ???
 
   def gray(n: Int): List[String] = ???
   def huffman(list: List[(String,  Int)]): List[(String, String)] = ???
-
 }

--- a/src/main/scala/s99/MultiwayTreesSolutions.scala
+++ b/src/main/scala/s99/MultiwayTreesSolutions.scala
@@ -11,9 +11,13 @@ trait MultiwayTreesSolutions {
     def nodeCount: Int = ???
     def show: String = ???
     def internalPathLength: Int = ???
-    def postorder: List[Char] = ???
+    def postOrder: List[Char] = ???
 
     def lispyTree: String = ???
+  }
+
+  object MTree {
+    def fromLispyTree(string: String): MTree[Char] = ???
   }
 
   implicit def string2MTree(s: String): MTree[Char] = ???

--- a/src/main/scala/s99/MultiwayTreesSolutions.scala
+++ b/src/main/scala/s99/MultiwayTreesSolutions.scala
@@ -11,7 +11,7 @@ trait MultiwayTreesSolutions {
     def nodeCount: Int = ???
     def show: String = ???
     def internalPathLength: Int = ???
-    def postOrder: List[Char] = ???
+    def postOrder: List[T] = ???
 
     def lispyTree: String = ???
   }

--- a/src/main/scala/s99/MultiwayTreesSolutions.scala
+++ b/src/main/scala/s99/MultiwayTreesSolutions.scala
@@ -1,7 +1,5 @@
 package s99
 
-import Solutions._
-
 trait MultiwayTreesSolutions {
 
   case class MTree[+T](value: T, children: List[MTree[T]] = Nil) {

--- a/src/main/scala/s99/MultiwayTreesSolutions.scala
+++ b/src/main/scala/s99/MultiwayTreesSolutions.scala
@@ -4,16 +4,15 @@ import Solutions._
 
 trait MultiwayTreesSolutions {
 
-  case class MTree[+T](value: T, children: List[MTree[T]] = List()) {
-
-    override def toString = "M(" + value.toString + " {" + children.map(_.toString).mkString(",") + "})"
-
+  case class MTree[+T](value: T, children: List[MTree[T]] = Nil) {
     def nodeCount: Int = ???
     def show: String = ???
     def internalPathLength: Int = ???
     def postOrder: List[T] = ???
 
     def lispyTree: String = ???
+
+    override def toString = s"M($value ${children.mkString(",")})"
   }
 
   object MTree {

--- a/src/main/scala/s99/Solutions.scala
+++ b/src/main/scala/s99/Solutions.scala
@@ -1,7 +1,8 @@
 package s99
 
+import org.specs2.execute.PendingException
 import org.specs2.matcher.ThrownExpectations
 
 object Solutions extends ThrownExpectations {
-  lazy val ??? = skipped("todo")
+  lazy val ??? = throw new PendingException(todo)
 }

--- a/src/main/scala/s99/Solutions.scala
+++ b/src/main/scala/s99/Solutions.scala
@@ -1,8 +1,0 @@
-package s99
-
-import org.specs2.execute.PendingException
-import org.specs2.matcher.ThrownExpectations
-
-object Solutions extends ThrownExpectations {
-  lazy val ??? = throw new PendingException(todo)
-}

--- a/src/test/scala/s99/ArithmeticSpec.scala
+++ b/src/test/scala/s99/ArithmeticSpec.scala
@@ -1,9 +1,8 @@
 package s99
 
-import org.specs2.mutable.Specification
 import org.specs2.matcher._
 
-class ArithmeticSpec extends Specification with ArithmeticSolutions {
+class ArithmeticSpec extends S99Specification with ArithmeticSolutions {
 
   "P31 Determine whether a given integer number is prime" >> {
     foreach(Seq(2, 3, 7, 13, 19)) { _ must bePrime }

--- a/src/test/scala/s99/ArithmeticSpec.scala
+++ b/src/test/scala/s99/ArithmeticSpec.scala
@@ -5,92 +5,135 @@ import org.specs2.matcher._
 
 class ArithmeticSpec extends Specification with ArithmeticSolutions {
 
-  "Determine whether a given integer number is prime" >>
-  { foreach(Seq(7, 13, 19)) { i => i must bePrime }
-    foreach(Seq(4, 9, 51))  { i => i must not(bePrime) } }
+  "P31 Determine whether a given integer number is prime" >> {
+    foreach(Seq(7, 13, 19)) { _ must bePrime }
+    foreach(Seq(1, 4, 9, 51)) { _ must not(bePrime) }
+  }
 
-  "Determine the greatest common divisor of two positive integer numbers. Use Euclid's algorithm" >>
-  { gcd(36, 63) === 9 }
+  "P32 Determine the greatest common divisor of two positive integer numbers. Use Euclid's algorithm" >> {
+    gcd(36, 63) === 9
+    gcd(11, 1) === 1
+    gcd(1, 11) === 1
+    gcd(348, 3792) === 12
+  }
 
-  """ Determine whether two positive integer numbers are coprime
-  Two numbers are coprime if their greatest common divisor equals 1""" >>
-  { 35 must beCoprimeTo(64) }
+  """P33 Determine whether two positive integer numbers are coprime
+  Two numbers are coprime if their greatest common divisor equals 1""" >> {
+    35 must beCoprimeTo(64)
 
-  """ Calculate Euler's totient function phi(m)
+    36 must not(beCoprimeTo(63))
+    11 must beCoprimeTo(1)
+    1 must beCoprimeTo(11)
+    348 must not(beCoprimeTo(3792))
+  }
+
+  """P34 Calculate Euler's totient function phi(m)
   Euler's so-called totient function phi(m) is defined as the number of positive integers r (1 <= r <= m) that are
-  coprime to m""" >>
-  { 10.totient === 4 }
+  coprime to m""" >> {
+    10.totient === 4
+    1.totient === 1
+    3792.totient === 1248
+  }
 
-  """ Determine the prime factors of a given positive integer
-  Construct a flat list containing the prime factors in ascending order""" >>
-  { 315.primeFactors === List(3, 3, 5, 7) }
+  """P35 Determine the prime factors of a given positive integer
+  Construct a flat list containing the prime factors in ascending order""" >> {
+    315.primeFactors === List(3, 3, 5, 7)
+    1.primeFactors === Nil
+    74.primeFactors === List(2, 37)
+  }
 
-  """ Determine the prime factors of a given positive integer (2)
-  Construct a list containing the prime factors and their multiplicity. Alternately, use a Map for the result""" >>
-  { 315.primeFactorMultiplicityMap === Map(3 -> 2, 5 -> 1, 7 -> 1)
-    315.primeFactorMultiplicity === List((3,2), (5,1), (7,1)) }
+  """P36 Determine the prime factors of a given positive integer (2)
+  Construct a list containing the prime factors and their multiplicity. Alternately, use a Map for the result""" >> {
+    315.primeFactorMultiplicityMap === Map(3 -> 2, 5 -> 1, 7 -> 1)
+    315.primeFactorMultiplicity === List((3, 2), (5, 1), (7, 1))
+    1.primeFactorMultiplicityMap === Map.empty
+    1.primeFactorMultiplicity === Nil
+    74.primeFactorMultiplicityMap === Map(2 -> 1, 37 -> 1)
+    74.primeFactorMultiplicity === List((2, 1), (37, 1))
+  }
 
-  """ Calculate Euler's totient function phi(m) (improved)
+  """P37 Calculate Euler's totient function phi(m) (improved)
   See problem P34 for the definition of Euler's totient function. If the list of the prime factors of a number m is
   known in the form of problem P36 then the function phi(m>1) can be efficiently calculated as follows:
   Let [[p1, m1], [p2, m2], [p3, m3], ...] be the list of prime factors (and their multiplicities) of a given number m.
   Then phi(m) can be calculated with the following formula:
 
-    phi(m) = (p1-1)*p1(m1-1) * (p2-1)*p2(m2-1) * (p3-1)*p3(m3-1) * ...
+    phi(m) = (p1-1) * p1^(m1-1) * (p2-1) * p2^(m2-1) * (p3-1) * p3^(m3-1) * ...
 
-  Note that ab stands for the bth power of a.""" >>
-  { 10.improvedTotient === 4 }
+  Note that a^b stands for the bth power of a.""" >> {
+    10.improvedTotient === 4
+    10.improvedTotient === 4
+    1.improvedTotient === 1
+    3792.improvedTotient === 1248
+  }
 
-  """ Compare the two methods of calculating Euler's totient function
-  Use the solutions of problems P34 and P37 to compare the algorithms. Try to calculate phi(10090) as an example""" >>
-  { val (r1, t1) = withTime(10090.totient)
+  """P38 Compare the two methods of calculating Euler's totient function
+  Use the solutions of problems P34 and P37 to compare the algorithms. Try to calculate phi(10090) as an example""" >> {
+    val (r1, t1) = withTime(10090.totient)
     val (r2, t2) = withTime(10090.improvedTotient)
     r1 === r2
-    t1 must be_>(t2) }
+    t1 must be_>(t2)
+  }
 
-  """ A list of prime numbers
-  Given a range of integers by its lower and upper limit, construct a list of all prime numbers in that range""" >>
-  {  listPrimesinRange(7 to 31) === List(7, 11, 13, 17, 19, 23, 29, 31) }
+  """P39 A list of prime numbers
+  Given a range of integers by its lower and upper limit, construct a list of all prime numbers in that range""" >> {
+    listPrimesinRange(7 to 31) === List(7, 11, 13, 17, 19, 23, 29, 31)
+    listPrimesinRange(1 to 1) === Nil
+    listPrimesinRange(3 to 2) === Nil
+  }
 
-  """ Goldbach's conjecture
+  """P40 Goldbach's conjecture
   Goldbach's conjecture says that every positive even number greater than 2 is the sum of two prime numbers.
   E.g. 28 = 5 + 23. It is one of the most famous facts in number theory that has not been proved to be correct in the
   general case. It has been numerically confirmed up to very large numbers (much larger than Scala's Int can represent).
-  Write a function to find the two prime numbers that sum up to a given even integer""" >>
-  { 28.goldbach === (5, 23) }
+  Write a function to find the two prime numbers that sum up to a given even integer""" >> {
+    28.goldbach must beOneOf((5, 23), (11, 17))
+    74.goldbach must beOneOf((3, 71), (7, 67), (13, 61), (31, 43))
+    4.goldbach === (2, 2)
+  }
 
-  """ A list of Goldbach compositions
+  """P41 A list of Goldbach compositions
   Given a range of integers by its lower and upper limit, print a list of all even numbers and their Goldbach
   composition. In most cases, if an even number is written as the sum of two prime numbers, one of them is very small.
   Very rarely, the primes are both bigger than, say, 50. Try to find out how many such cases there are in the
-  range 2..3000""" >>
-  { printGoldbachList(9 to 20) === List(
-      "9 = 2 + 7",
+  range 2..3000""" >> {
+    printGoldbachList(9 to 20) === List(
       "10 = 3 + 7",
-      "11 = 11 + 0",
       "12 = 1 + 11",
-      "13 = 2 + 11",
       "14 = 1 + 13",
-      "15 = 2 + 13",
       "16 = 3 + 13",
-      "17 = 17 + 0",
       "18 = 1 + 17",
-      "19 = 2 + 17",
       "20 = 1 + 19")
+
+    printGoldbachList(3 to 3) === Nil
+
+    printGoldbachListLimited(9 to 20, 1) === List(
+      "10 = 3 + 7",
+      "12 = 1 + 11",
+      "14 = 1 + 13",
+      "16 = 3 + 13",
+      "18 = 1 + 17",
+      "20 = 1 + 19")
+
+    printGoldbachListLimited(9 to 20, 2) === List(
+      "10 = 3 + 7",
+      "16 = 3 + 13")
 
     printGoldbachListLimited(1 to 2000, 50) === List(
       "992 = 73 + 919",
       "1382 = 61 + 1321",
       "1856 = 67 + 1789",
-      "1928 = 61 + 1867") }
+      "1928 = 61 + 1867")
+  }
 
-  def bePrime: Matcher[Int]             = (i: Int) => (i.isPrime, i+" is not prime")
-  def beCoprimeTo(j: Int): Matcher[Int] = (i: Int) => (i.isCoprimeTo(j), i+" is not coprime to"+j)
+  def bePrime: Matcher[Int] = (i: Int) => (i.isPrime, i + " is not prime")
+
+  def beCoprimeTo(j: Int): Matcher[Int] = (i: Int) => (i.isCoprimeTo(j), i + " is not coprime to" + j)
 
   /**
    * @return the result of a computation with the time in millis to compute it
    */
-  def withTime[T](t: =>T): (T, Long) = {
+  def withTime[T](t: => T): (T, Long) = {
     val start = System.currentTimeMillis()
     (t, System.currentTimeMillis() - start)
   }

--- a/src/test/scala/s99/ArithmeticSpec.scala
+++ b/src/test/scala/s99/ArithmeticSpec.scala
@@ -6,8 +6,8 @@ import org.specs2.matcher._
 class ArithmeticSpec extends Specification with ArithmeticSolutions {
 
   "P31 Determine whether a given integer number is prime" >> {
-    foreach(Seq(7, 13, 19)) { _ must bePrime }
-    foreach(Seq(1, 4, 9, 51)) { _ must not(bePrime) }
+    foreach(Seq(2, 3, 7, 13, 19)) { _ must bePrime }
+    foreach(Seq(1, 4, 9, 25, 51)) { _ must not(bePrime) }
   }
 
   "P32 Determine the greatest common divisor of two positive integer numbers. Use Euclid's algorithm" >> {
@@ -69,8 +69,8 @@ class ArithmeticSpec extends Specification with ArithmeticSolutions {
 
   """P38 Compare the two methods of calculating Euler's totient function
   Use the solutions of problems P34 and P37 to compare the algorithms. Try to calculate phi(10090) as an example""" >> {
-    val (r1, t1) = withTime(10090.totient)
-    val (r2, t2) = withTime(10090.improvedTotient)
+    val (r1, t1) = withTimeRepeated(100)(10090.totient)
+    val (r2, t2) = withTimeRepeated(100)(10090.improvedTotient)
     r1 === r2
     t1 must be_>(t2)
   }
@@ -87,8 +87,11 @@ class ArithmeticSpec extends Specification with ArithmeticSolutions {
   E.g. 28 = 5 + 23. It is one of the most famous facts in number theory that has not been proved to be correct in the
   general case. It has been numerically confirmed up to very large numbers (much larger than Scala's Int can represent).
   Write a function to find the two prime numbers that sum up to a given even integer""" >> {
-    28.goldbach must beOneOf((5, 23), (11, 17))
-    74.goldbach must beOneOf((3, 71), (7, 67), (13, 61), (31, 43))
+    // Note: these tests consider that the function must return the Goldbach pair which contains the minimum element
+    // (although more than one valid pair can exist). This restriction is enforced because the result of this function
+    // strongly affects the expected results of P41 and it complies with the examples in the original problem statement.
+    28.goldbach === (5, 23)
+    74.goldbach === (3, 71)
     4.goldbach === (2, 2)
   }
 
@@ -99,25 +102,33 @@ class ArithmeticSpec extends Specification with ArithmeticSolutions {
   range 2..3000""" >> {
     printGoldbachList(9 to 20) === List(
       "10 = 3 + 7",
-      "12 = 1 + 11",
-      "14 = 1 + 13",
+      "12 = 5 + 7",
+      "14 = 3 + 11",
       "16 = 3 + 13",
-      "18 = 1 + 17",
-      "20 = 1 + 19")
+      "18 = 5 + 13",
+      "20 = 3 + 17")
+
+    printGoldbachList(9 to 20 by 2) === Nil
+
+    printGoldbachList(9 to 20 by 3) === List(
+      "12 = 5 + 7",
+      "18 = 5 + 13")
 
     printGoldbachList(3 to 3) === Nil
 
     printGoldbachListLimited(9 to 20, 1) === List(
       "10 = 3 + 7",
-      "12 = 1 + 11",
-      "14 = 1 + 13",
+      "12 = 5 + 7",
+      "14 = 3 + 11",
       "16 = 3 + 13",
-      "18 = 1 + 17",
-      "20 = 1 + 19")
+      "18 = 5 + 13",
+      "20 = 3 + 17")
 
-    printGoldbachListLimited(9 to 20, 2) === List(
-      "10 = 3 + 7",
-      "16 = 3 + 13")
+    printGoldbachListLimited(9 to 20, 3) === List(
+      "12 = 5 + 7",
+      "18 = 5 + 13")
+
+    printGoldbachListLimited(9 to 20, 5) === Nil
 
     printGoldbachListLimited(1 to 2000, 50) === List(
       "992 = 73 + 919",
@@ -136,5 +147,10 @@ class ArithmeticSpec extends Specification with ArithmeticSolutions {
   def withTime[T](t: => T): (T, Long) = {
     val start = System.currentTimeMillis()
     (t, System.currentTimeMillis() - start)
+  }
+
+  def withTimeRepeated[T](times: Int)(t: => T): (T, Long) = {
+    val start = System.currentTimeMillis()
+    ((1 to times).map(_ => t).head, System.currentTimeMillis() - start)
   }
 }

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -217,8 +217,17 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   Write a method layoutBinaryTree that turns a tree of normal Nodes into a tree of PositionedNodes
 
   The tree at right may be constructed with `Tree.fromList(List('n','k','m','c','a','h','g','e','u','p','s','q'))`.
-  Use it to check your code""" >>
-  { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree.toString === "T[3,1](a T[1,2](b . T[2,3](c . .)) T[4,2](d . .))" }
+  Use it to check your code""" >> {
+    Node(0).layoutBinaryTree.toString === "T[1,1](0 . .)"
+    Node(0, Node(1), End).layoutBinaryTree.toString === "T[2,1](0 T[1,2](1 . .) .)"
+    Node(0, End, Node(1)).layoutBinaryTree.toString === "T[1,1](0 . T[2,2](1 . .))"
+    Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree.toString ===
+      "T[3,1](a T[1,2](b . T[2,3](c . .)) T[4,2](d . .))"
+    Node(0, Node(1, Node(2, Node(3), End), End), End).layoutBinaryTree.toString ===
+      "T[4,1](0 T[3,2](1 T[2,3](2 T[1,4](3 . .) .) .) .)"
+    Node('a', Node('b', End, Node('c', End, Node('d'))), Node('e', Node('f'), End)).layoutBinaryTree.toString ===
+      "T[4,1](a T[1,2](b . T[2,3](c . T[3,4](d . .))) T[6,2](e T[5,3](f . .) .))"
+  }
 
   """P65 Layout a binary tree (2)
 
@@ -227,9 +236,21 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   conventions as in problem P64
 
   The tree at right may be constructed with `Tree.fromList(List('n','k','m','c','a','e','d','g','u','p','q'))`.
-  Use it to check your code""" >>
-  { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree2.toString ===
-      "T[3,1]('a T[1,2]('b . T[2,3]('c . .)) T[5,2]('d . .))" }
+  Use it to check your code""" >> {
+    // Note: these test cases may give more hints on the rules of this layout. Don't read them if you
+    // want to figure them out on your own
+    Node(0).layoutBinaryTree2.toString === "T[1,1](0 . .)"
+    Node(0, Node(1), End).layoutBinaryTree2.toString === "T[2,1](0 T[1,2](1 . .) .)"
+    Node(0, End, Node(1)).layoutBinaryTree2.toString === "T[1,1](0 . T[2,2](1 . .))"
+    Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree2.toString ===
+      "T[3,1](a T[1,2](b . T[2,3](c . .)) T[5,2](d . .))"
+    Node(0, Node(1, Node(2, Node(3), End), End), End).layoutBinaryTree2.toString ===
+      "T[8,1](0 T[4,2](1 T[2,3](2 T[1,4](3 . .) .) .) .)"
+    Node(0, Node(1, Node(2, Node(3), Node(4, Node(5), Node(6))), End), End).layoutBinaryTree2.toString ===
+      "T[15,1](0 T[7,2](1 T[3,3](2 T[1,4](3 . .) T[5,4](4 T[4,5](5 . .) T[6,5](6 . .))) .) .)"
+    Node('a', Node('b', End, Node('c', End, Node('d'))), Node('e', Node('f'), End)).layoutBinaryTree2.toString ===
+      "T[5,1](a T[1,2](b . T[3,3](c . T[4,4](d . .))) T[9,2](e T[7,3](f . .) .))"
+  }
 
   """P66 Layout a binary tree (3)
 
@@ -239,9 +260,24 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   subtrees to construct the combined binary tree? Use the same conventions as in problem P64 and P65.
   Note: This is a difficult problem. Don't give up too early!
 
-  Which layout do you like most?""" >>
-  { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
-      "T[2,1]('a T[1,2]('b . T[2,3]('c . .)) T[3,2]('d . .))" }
+  Which layout do you like most?""" >> {
+    // Note: these test cases may give more hints on the rules of this layout. Don't read them if you
+    // want to figure them out on your own
+    Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
+      "T[2,1]('a T[1,2]('b . T[2,3]('c . .)) T[3,2]('d . .))"
+
+    Node(0).layoutBinaryTree3.toString === "T[1,1](0 . .)"
+    Node(0, Node(1), End).layoutBinaryTree3.toString === "T[2,1](0 T[1,2](1 . .) .)"
+    Node(0, End, Node(1)).layoutBinaryTree3.toString === "T[1,1](0 . T[2,2](1 . .))"
+    Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
+      "T[3,1](a T[1,2](b . T[2,3](c . .)) T[5,2](d . .))"
+    Node(0, Node(1, Node(2, Node(3), End), End), End).layoutBinaryTree3.toString ===
+      "T[4,1](0 T[3,2](1 T[2,3](2 T[1,4](3 . .) .) .) .)"
+    Node(0, Node(1, Node(2, Node(3), Node(4, Node(5), Node(6))), End), End).layoutBinaryTree3.toString ===
+      "T[4,1](0 T[3,2](1 T[2,3](2 T[1,4](3 . .) T[3,4](4 T[2,5](5 . .) T[4,5](6 . .))) .) .)"
+    Node('a', Node('b', End, Node('c', End, Node('d'))), Node('e', Node('f'), End)).layoutBinaryTree3.toString ===
+      "T[3,1](a T[1,2](b . T[2,3](c . T[3,4](d . .))) T[5,2](e T[4,3](f . .) .))"
+  }
 
   """P67 A string representation of binary trees
 

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -38,16 +38,16 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   Define an object named Tree. Write a function Tree.cBalanced to construct completely balanced binary trees for a
   given number of nodes. The function should generate all solutions. The function should take as parameters the number
   of nodes and a single value to put in all of them""" >> {
+    Tree.cBalanced(0, 0) === List(End)
+    Tree.cBalanced(1, 0) === List(Node(0))
     Tree.cBalanced(4, "x").toSet === Set(
       Node("x", Node("x", End, End), Node("x", Node("x"), End)),
       Node("x", Node("x", End, End), Node("x", End, Node("x"))),
       Node("x", Node("x", Node("x"), End), Node("x", End, End)),
       Node("x", Node("x", End, Node("x")), Node("x", End, End))
     )
-    Tree.cBalanced(0, 0) === List(End)
-    Tree.cBalanced(1, 0) === List(Node(0))
-    Tree.cBalanced(10, 'a).length === 56
-    Tree.cBalanced(11, 'a).length === 70
+    Tree.cBalanced(10, 'a).length === 32
+    Tree.cBalanced(11, 'a).length === 16
   }
 
   """P56 Symmetric binary trees
@@ -56,9 +56,9 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   is the mirror image of the left subtree. Add an isSymmetric method to the Tree class to check whether a given binary
   tree is symmetric. Hint: Write an isMirrorOf method first to check whether one tree is the mirror image of another.
   We are only interested in the structure, not in the contents of the nodes""" >> {
-    Node('a', Node('b'), Node('c')).isSymmetric must beTrue
     End.isSymmetric must beTrue
     Node(0).isSymmetric must beTrue
+    Node('a', Node('b'), Node('c')).isSymmetric must beTrue
     Node('a', Node('b', Node('x'), End), Node('c', End, Node('x'))).isSymmetric must beTrue
     Node(0, Node(1), End).isSymmetric must beFalse
     Node('a', Node('b', End, Node('x')), Node('c', End, Node('x'))).isSymmetric must beFalse
@@ -88,11 +88,11 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
 
   Apply the generate-and-test paradigm to construct all symmetric, completely balanced
   binary trees with a given number of nodes""" >> {
+    Tree.symmetricBalancedTrees(0, 0) === List(End)
+    Tree.symmetricBalancedTrees(2, 0) === Nil
     Tree.symmetricBalancedTrees(5, "x").toString ===
       "List(T(x T(x . T(x . .)) T(x T(x . .) .)), T(x T(x T(x . .) .) T(x . T(x . .))))"
-    Tree.symmetricBalancedTrees(0, 0) === List(End)
-    Tree.symmetricBalancedTrees(2, 0).toString === Nil
-    Tree.symmetricBalancedTrees(11, 'a).length === 6
+    Tree.symmetricBalancedTrees(11, 'a).length === 4
   }
 
   """P59 Construct height-balanced binary trees
@@ -101,13 +101,13 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   node: The height of its left subtree and the height of its right subtree are almost equal, which means their
   difference is not greater than one. Write a method `Tree.hbalTrees` to construct height-balanced binary trees for a
   given height with a supplied value for the nodes. The function should generate all solutions""" >> {
+    Tree.hbalTrees(0, 0) === List(End)
+    Tree.hbalTrees(1, 'a) === List(Node('a))
     Tree.hbalTrees(3, "x").map(_.toString) must contain(
       "T(x T(x T(x . .) T(x . .)) T(x T(x . .) T(x . .)))",
       "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))",
       "T(x T(x T(x . .) .) T(x . .))"
     )
-    Tree.hbalTrees(0, 0) === List(End)
-    Tree.hbalTrees(1, 'a) === List(Node('a))
   }
 
   """P60 Construct height-balanced binary trees with a given number of nodes
@@ -132,35 +132,35 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   """P61 Count the leaves of a binary tree
 
   A leaf is a node with no successors. Write a method leafCount to count them""" >> {
-    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafCount === 3
-    Node('x', Node('y'), End).leafCount === 1
     End.leafCount === 0
     Node('a).leafCount === 1
+    Node('x', Node('y'), End).leafCount === 1
     Node(0, Node(1, Node(2), End), End).leafCount === 1
     Node(0, Node(1, Node(2), End), Node(3)).leafCount === 2
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafCount === 3
   }
 
   """P61A Collect the leaves of a binary tree in a list
 
   A leaf is a node with no successors. Write a method leafList to collect them in a list""" >> {
-    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafList === List('b', 'd', 'e')
-    Node('x', Node('y'), End).leafCount === List(Node('y'))
     End.leafList === Nil
     Node('a).leafList === List('a)
+    Node('x', Node('y'), End).leafList === List('y')
     Node(0, Node(1, Node(2), End), End).leafList === List(2)
     Node(0, Node(1, Node(2), End), Node(3)).leafList.toSet === Set(2, 3)
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafList === List('b', 'd', 'e')
   }
 
   """P62 Collect the internal nodes of a binary tree in a list
 
   An internal node of a binary tree has either one or two
   non-empty successors. Write a method internalList to collect them in a list""" >> {
+    End.internalList === Nil
+    Node('a).internalList === Nil
+    Node('x', Node('y'), End).internalList === List('x')
+    Node(0, Node(1, Node(2), End), End).internalList.toSet === Set(0, 1)
+    Node(0, Node(1, Node(2), End), Node(3)).internalList.toSet === Set(0, 1)
     Node('a', Node('b'), Node('c', Node('d'), Node('e'))).internalList === List('a', 'c')
-    Node('x', Node('x'), End).leafCount === List(Node('x'))
-    End.leafList === Nil
-    Node('a).leafList === Nil
-    Node(0, Node(1, Node(2), End), End).leafList.toSet === Set(0, 1)
-    Node(0, Node(1, Node(2), End), Node(3)).leafList.toSet === Set(0, 1)
   }
 
   """P62B Collect the nodes at a given level in a list
@@ -169,12 +169,12 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   level 1. Write a method atLevel to collect all nodes at a given level in a list.
   Using `atLevel` it is easy to construct a method levelOrder which creates the level-order sequence of the nodes.
   However, there are more efficient ways to do that""" >> {
-    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(2) === List('b', 'c')
-    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(1) === List('a')
-    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(4) === Nil
     End.atLevel(1) === Nil
     End.atLevel(5) === Nil
     Node('a).atLevel(1) === List('a)
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(2) === List('b', 'c')
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(1) === List('a')
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(4) === Nil
   }
 
   """P63 Construct a complete binary tree
@@ -191,9 +191,9 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   property holds: The address of X's left and right successors are 2*A and 2*A+1, respectively, supposed the successors
   do exist. This fact can be used to elegantly construct a complete binary tree structure. Write a method
   completeBinaryTree` that takes as parameters the number of nodes and the value to put in each node""" >> {
-    Tree.completeBinaryTree(6, "x").toString === "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))"
     Tree.completeBinaryTree(0, 0) === End
     Tree.completeBinaryTree(1, 0).toString === "T(0 . .)"
+    Tree.completeBinaryTree(6, "x").toString === "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))"
   }
 
   """P64 Layout a binary tree (1)

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -3,15 +3,15 @@ package s99
 import org.specs2.mutable.Specification
 
 class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
-  """ A binary tree is either empty or it is composed of a root element and two successors, which are binary trees
+  /*
+  A binary tree is either empty or it is composed of a root element and two successors, which are binary trees
   themselves.
 
-  We shall use the following classes to represent binary trees. (Also available in tree1.scala.) An End is equivalent
-  to an empty tree. A Branch has a value, and two descendant trees. The toString functions are relatively arbitrary,
-  but they yield a more compact output than Scala's default. Putting a plus in front of the T makes the class
-  covariant; it will be able to hold subtypes of whatever type it's created for. (This is important so that End can
-  be a singleton object; as a singleton, it must have a specific type, so we give it type Nothing, which is a subtype
-  of every other type.)
+  We shall use the following classes to represent binary trees. An End is equivalent to an empty tree. A Node has
+  a value, and two descendant trees. The toString functions are relatively arbitrary, but they yield a more compact
+  output than Scala's default. Putting a plus in front of the T makes the class covariant; it will be able to hold
+  subtypes of whatever type it's created for. (This is important so that End can be a singleton object; as a
+  singleton, it must have a specific type, so we give it type Nothing, which is a subtype of every other type.)
 
        sealed abstract class Tree[+T]
        case class Node[+T](value: T, left: Tree[T], right: Tree[T]) extends Tree[T] {
@@ -24,34 +24,47 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
          def apply[T](value: T): Node[T] = Node(value, End, End)
        }
 
-  The example tree on the right is given by
-
-       Node('a',
-            Node('b', Node('d'), Node('e')),
-            Node('c', End, Node('f', Node('g'), End)))
-
   A tree with only a root node would be Node('a') and an empty tree would be End.
 
-  Throughout this section, we will be adding methods to the classes above, mostly to Tree"""
+  Throughout this section, we will be adding methods to the classes above, mostly to Tree.
+  */
 
-  """ Construct completely balanced binary trees
+  """P55 Construct completely balanced binary trees
 
   In a completely balanced binary tree, the following property holds for every node: The number of nodes in its left
   subtree and the number of nodes in its right subtree are almost equal, which means their difference is not greater
-  than one. Define an object named Tree. Write a function Tree.cBalanced to construct completely balanced binary trees
-  for a given number of nodes. The function should generate all solutions. The function should take as parameters the
-  number of nodes and a single value to put in all of them""" >>
-  { Tree.cBalanced(4, "x") must contain ("T(x T(x . .) T(x . T(x . .)))", "T(x T(x . .) T(x T(x . .) .))") }
+  than one.
 
-  """ Symmetric binary trees
+  Define an object named Tree. Write a function Tree.cBalanced to construct completely balanced binary trees for a
+  given number of nodes. The function should generate all solutions. The function should take as parameters the number
+  of nodes and a single value to put in all of them""" >> {
+    Tree.cBalanced(4, "x").toSet === Set(
+      Node("x", Node("x", End, End), Node("x", Node("x"), End)),
+      Node("x", Node("x", End, End), Node("x", End, Node("x"))),
+      Node("x", Node("x", Node("x"), End), Node("x", End, End)),
+      Node("x", Node("x", End, Node("x")), Node("x", End, End))
+    )
+    Tree.cBalanced(0, 0) === List(End)
+    Tree.cBalanced(1, 0) === List(Node(0))
+    Tree.cBalanced(10, 'a).length === 56
+    Tree.cBalanced(11, 'a).length === 70
+  }
+
+  """P56 Symmetric binary trees
 
   Let us call a binary tree symmetric if you can draw a vertical line through the root node and then the right subtree
   is the mirror image of the left subtree. Add an isSymmetric method to the Tree class to check whether a given binary
   tree is symmetric. Hint: Write an isMirrorOf method first to check whether one tree is the mirror image of another.
-  We are only interested in the structure, not in the contents of the nodes""" >>
-  { Node('a', Node('b'), Node('c')).isSymmetric must beTrue }
+  We are only interested in the structure, not in the contents of the nodes""" >> {
+    Node('a', Node('b'), Node('c')).isSymmetric must beTrue
+    End.isSymmetric must beTrue
+    Node(0).isSymmetric must beTrue
+    Node('a', Node('b', Node('x'), End), Node('c', End, Node('x'))).isSymmetric must beTrue
+    Node(0, Node(1), End).isSymmetric must beFalse
+    Node('a', Node('b', End, Node('x')), Node('c', End, Node('x'))).isSymmetric must beFalse
+  }
 
-  """ Binary search trees (dictionaries)
+  """P57 Binary search trees (dictionaries)
 
   Write a function to add an element to a binary search tree.
   Hint: The abstract definition of addValue in Tree should be
@@ -61,31 +74,43 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   the `<` operator on the values in the tree.
 
   Use that function to construct a binary tree from a list of integers.
-  Finally, use that function to test your solution to P56""" >>
-  { End.addValue(2).toString === "T(2 . .)"
+  Finally, use that function to test your solution to P56""" >> {
+    End.addValue(2).toString === "T(2 . .)"
     End.addValue(2).addValue(3).toString === "T(2 . T(3 . .))"
     End.addValue(2).addValue(3).addValue(0).toString === "T(2 T(0 . .) T(3 . .))"
 
     Tree.fromList(List(3, 2, 5, 7, 1)).toString === "T(3 T(2 T(1 . .) .) T(5 . T(7 . .)))"
     Tree.fromList(List(5, 3, 18, 1, 4, 12, 21)).isSymmetric must beTrue
-    Tree.fromList(List(3, 2, 5, 7, 4)).isSymmetric must beFalse }
+    Tree.fromList(List(3, 2, 5, 7, 4)).isSymmetric must beFalse
+  }
 
-  """ Generate-and-test paradigm
+  """P58 Generate-and-test paradigm
 
   Apply the generate-and-test paradigm to construct all symmetric, completely balanced
-  binary trees with a given number of nodes""" >>
-  { Tree.symmetricBalancedTrees(5, "x").toString === "List(T(x T(x . T(x . .)) T(x T(x . .) .)), T(x T(x T(x . .) .) T(x . T(x . .))))" }
+  binary trees with a given number of nodes""" >> {
+    Tree.symmetricBalancedTrees(5, "x").toString ===
+      "List(T(x T(x . T(x . .)) T(x T(x . .) .)), T(x T(x T(x . .) .) T(x . T(x . .))))"
+    Tree.symmetricBalancedTrees(0, 0) === List(End)
+    Tree.symmetricBalancedTrees(2, 0).toString === Nil
+    Tree.symmetricBalancedTrees(11, 'a).length === 6
+  }
 
-  """ Construct height-balanced binary trees
+  """P59 Construct height-balanced binary trees
 
   In a height-balanced binary tree, the following property holds for every
   node: The height of its left subtree and the height of its right subtree are almost equal, which means their
   difference is not greater than one. Write a method `Tree.hbalTrees` to construct height-balanced binary trees for a
-  given height with a supplied value for the nodes. The function should generate all solutions""" >>
-  { Tree.hbalTrees(3, "x").map(_.toString) must contain("T(x T(x T(x . .) T(x . .)) T(x T(x . .) T(x . .)))",
-      "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))") }
+  given height with a supplied value for the nodes. The function should generate all solutions""" >> {
+    Tree.hbalTrees(3, "x").map(_.toString) must contain(
+      "T(x T(x T(x . .) T(x . .)) T(x T(x . .) T(x . .)))",
+      "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))",
+      "T(x T(x T(x . .) .) T(x . .))"
+    )
+    Tree.hbalTrees(0, 0) === List(End)
+    Tree.hbalTrees(1, 'a) === List(Node('a))
+  }
 
-  """ Construct height-balanced binary trees with a given number of nodes
+  """P60 Construct height-balanced binary trees with a given number of nodes
 
   Consider a height-balanced binary tree of height H. What is the maximum number of nodes it can contain? Clearly,
   MaxN = 2H - 1. However, what is the minimum number MinN? This question is more difficult. Try to find a recursive
@@ -94,37 +119,65 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   On the other hand, we might ask: what is the maximum height H a height-balanced binary tree with N nodes can have?
   Write a maxHbalHeight function.
   Now, we can attack the main problem: construct all the height-balanced binary trees with a given nuber of nodes.
-  Find out how many height-balanced trees exist for N = 15""" >>
-  { Tree.minHbalNodes(3) === 4
+  Find out how many height-balanced trees exist for N = 15""" >> {
+    Tree.minHbalNodes(0) === 0
+    Tree.minHbalNodes(3) === 4
     Tree.maxHbalHeight(4) === 3
-    Tree.hbalTreesWithNodes(4, "x").map(_.toString) must contain ("T(x T(x T(x . .) .) T(x . .))", "T(x T(x . T(x . .)) T(x . .))") }
+    Tree.hbalTreesWithNodes(4, "x").map(_.toString) must contain (
+      "T(x T(x T(x . .) .) T(x . .))",
+      "T(x T(x . T(x . .)) T(x . .))"
+    )
+  }
 
-  """ Count the leaves of a binary tree
+  """P61 Count the leaves of a binary tree
 
-  A leaf is a node with no successors. Write a method leafCount to count them.""" >>
-  { Node('x', Node('x'), End).leafCount === 1 }
+  A leaf is a node with no successors. Write a method leafCount to count them""" >> {
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafCount === 3
+    Node('x', Node('y'), End).leafCount === 1
+    End.leafCount === 0
+    Node('a).leafCount === 1
+    Node(0, Node(1, Node(2), End), End).leafCount === 1
+    Node(0, Node(1, Node(2), End), Node(3)).leafCount === 2
+  }
 
-  """ Collect the leaves of a binary tree in a list
+  """P61A Collect the leaves of a binary tree in a list
 
-  A leaf is a node with no successors. Write a method leafList to
-  collect them in a list""" >>
-  { Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafList === List('b', 'd', 'e') }
+  A leaf is a node with no successors. Write a method leafList to collect them in a list""" >> {
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).leafList === List('b', 'd', 'e')
+    Node('x', Node('y'), End).leafCount === List(Node('y'))
+    End.leafList === Nil
+    Node('a).leafList === List('a)
+    Node(0, Node(1, Node(2), End), End).leafList === List(2)
+    Node(0, Node(1, Node(2), End), Node(3)).leafList.toSet === Set(2, 3)
+  }
 
-  """ Collect the internal nodes of a binary tree in a list
+  """P62 Collect the internal nodes of a binary tree in a list
 
   An internal node of a binary tree has either one or two
-  non-empty successors. Write a method internalList to collect them in a list""" >>
-  { Node('a', Node('b'), Node('c', Node('d'), Node('e'))).internalList === List('a', 'c') }
+  non-empty successors. Write a method internalList to collect them in a list""" >> {
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).internalList === List('a', 'c')
+    Node('x', Node('x'), End).leafCount === List(Node('x'))
+    End.leafList === Nil
+    Node('a).leafList === Nil
+    Node(0, Node(1, Node(2), End), End).leafList.toSet === Set(0, 1)
+    Node(0, Node(1, Node(2), End), Node(3)).leafList.toSet === Set(0, 1)
+  }
 
-  """ Collect the nodes at a given level in a list
+  """P62B Collect the nodes at a given level in a list
 
   A node of a binary tree is at level N if the path from the root to the node has length N-1. The root node is at
   level 1. Write a method atLevel to collect all nodes at a given level in a list.
   Using `atLevel` it is easy to construct a method levelOrder which creates the level-order sequence of the nodes.
-  However, there are more efficient ways to do that""" >>
-  { Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(2) === List('b', 'c') }
+  However, there are more efficient ways to do that""" >> {
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(2) === List('b', 'c')
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(1) === List('a')
+    Node('a', Node('b'), Node('c', Node('d'), Node('e'))).atLevel(4) === Nil
+    End.atLevel(1) === Nil
+    End.atLevel(5) === Nil
+    Node('a).atLevel(1) === List('a)
+  }
 
-  """ Construct a complete binary tree
+  """P63 Construct a complete binary tree
 
   A complete binary tree with height H is defined as follows: The levels 1,2,3,...,H-1 contain the maximum number of
   nodes (i.e 2(i-1) at the level i, note that we start counting the levels from 1 at the root). In level H, which may
@@ -137,10 +190,13 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   starting at the root with number 1. In doing so, we realize that for every node X with address A the following
   property holds: The address of X's left and right successors are 2*A and 2*A+1, respectively, supposed the successors
   do exist. This fact can be used to elegantly construct a complete binary tree structure. Write a method
-  completeBinaryTree` that takes as parameters the number of nodes and the value to put in each node""" >>
-  { Tree.completeBinaryTree(6, "x").toString === "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))" }
+  completeBinaryTree` that takes as parameters the number of nodes and the value to put in each node""" >> {
+    Tree.completeBinaryTree(6, "x").toString === "T(x T(x T(x . .) T(x . .)) T(x T(x . .) .))"
+    Tree.completeBinaryTree(0, 0) === End
+    Tree.completeBinaryTree(1, 0).toString === "T(0 . .)"
+  }
 
-  """ Layout a binary tree (1)
+  """P64 Layout a binary tree (1)
 
   As a preparation for drawing a tree, a layout algorithm is required to determine the position of each node in a
   rectangular grid. Several layout methods are conceivable, one of them is shown in the illustration on the right.
@@ -164,7 +220,7 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   Use it to check your code""" >>
   { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree.toString === "T[3,1](a T[1,2](b . T[2,3](c . .)) T[4,2](d . .))" }
 
-  """ Layout a binary tree (2)
+  """P65 Layout a binary tree (2)
 
   An alternative layout method is depicted in the illustration opposite. Find out the rules and write the corresponding
   method. Hint: On a given level, the horizontal distance between neighboring nodes is constant. Use the same
@@ -175,7 +231,7 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree2.toString ===
       "T[3,1]('a T[1,2]('b . T[2,3]('c . .)) T[5,2]('d . .))" }
 
-  """ Layout a binary tree (3)
+  """P66 Layout a binary tree (3)
 
   Yet another layout strategy is shown in the illustration opposite. The method yields a very compact layout while
   maintaining a certain symmetry in every node. Find out the rules and write the corresponding method.
@@ -187,7 +243,7 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   { Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
       "T[2,1]('a T[1,2]('b . T[2,3]('c . .)) T[3,2]('d . .))" }
 
-  """ A string representation of binary trees
+  """P67 A string representation of binary trees
 
   Somebody represents binary trees as strings of the following type (see example opposite):
     a(b(d,e),c(,f(g,)))
@@ -202,7 +258,7 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
 
       Tree.fromString("a(b(d,e),c(,f(g,)))").show === "a(b(d,e),c(,f(g,)))" }
 
-  """ Preorder and inorder sequences of binary trees
+  """P68 Preorder and inorder sequences of binary trees
 
   We consider binary trees with nodes that are identified by single lower-case letters, as in the example of problem P67.
     a) Write methods preorder and inorder that construct the preorder and inorder sequence of a given binary tree,
@@ -218,7 +274,7 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
     Tree.preInTree(List('a', 'b', 'd', 'e', 'c', 'f', 'g'), List('d', 'b', 'e', 'a', 'c', 'g', 'f')).show ===
      "a(b(d,e),c(,f(g,)))" }
 
-  """ Dotstring representation of binary trees
+  """P69 Dotstring representation of binary trees
 
   We consider again binary trees with nodes that are identified by single lower-case letters, as in the example of
   problem P67. Such a tree can be represented by the preorder sequence of its nodes in which dots (.) are inserted

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -354,11 +354,20 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   Use that method for the Tree class's and subclass's toString methods. Then write a method (on the Tree object) which
   does this inverse; i.e. given the string representation, construct the tree in the usual form.
 
-  For simplicity, suppose the information in the nodes is a single letter and there are no spaces in the string""" >>
-  { Node('a', Node('b', Node('d'), Node('e')), Node('c', End, Node('f', Node('g'), End))).show ===
+  For simplicity, suppose the information in the nodes is a single letter and there are no spaces in the string""" >> {
+    Node('a', Node('b', Node('d'), Node('e')), Node('c', End, Node('f', Node('g'), End))).show ===
       "a(b(d,e),c(,f(g,)))"
 
-      Tree.fromString("a(b(d,e),c(,f(g,)))").show === "a(b(d,e),c(,f(g,)))" }
+    Node('a').show === "a"
+    Node('a', Node('b'), End).show === "a(b,)"
+    Node('a', End, Node('b')).show === "a(,b)"
+
+    Tree.fromString("a") === Node('a')
+    Tree.fromString("a(b,)") === Node('a', Node('b'), End)
+    Tree.fromString("a(,b)") === Node('a', End, Node('b'))
+
+    Tree.fromString("a(b(d,e),c(,f(g,)))").show === "a(b(d,e),c(,f(g,)))"
+  }
 
   """P68 Preorder and inorder sequences of binary trees
 
@@ -370,11 +379,12 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
        is determined unambiguously. Write a method preInTree that does the job.
 
   What happens if the same character appears in more than one node? Try, for instance,
-  `Tree.preInTree(List('a', 'b', 'a'), List('b', 'a', 'a'))`""" >>
-  { Tree.string2Tree("a(b(d,e),c(,f(g,)))").preOrder === List('a', 'b', 'd', 'e', 'c', 'f', 'g')
-    Tree.string2Tree("a(b(d,e),c(,f(g,)))").inOrder === List('d', 'b', 'e', 'a', 'c', 'g', 'f')
+  `Tree.preInTree(List('a', 'b', 'a'), List('b', 'a', 'a'))`""" >> {
+    Tree.fromString("a(b(d,e),c(,f(g,)))").preOrder === List('a', 'b', 'd', 'e', 'c', 'f', 'g')
+    Tree.fromString("a(b(d,e),c(,f(g,)))").inOrder === List('d', 'b', 'e', 'a', 'c', 'g', 'f')
     Tree.preInTree(List('a', 'b', 'd', 'e', 'c', 'f', 'g'), List('d', 'b', 'e', 'a', 'c', 'g', 'f')).show ===
-     "a(b(d,e),c(,f(g,)))" }
+     "a(b(d,e),c(,f(g,)))"
+  }
 
   """P69 Dotstring representation of binary trees
 
@@ -382,8 +392,12 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   problem P67. Such a tree can be represented by the preorder sequence of its nodes in which dots (.) are inserted
   where an empty subtree (End) is encountered during the tree traversal. For example, the tree shown in problem P67
   is represented as "abd..e..c.fg...". First, try to establish a syntax (BNF or syntax diagrams) and then write two
-  methods, `toDotstring` and `fromDotstring`, which do the conversion in both directions""" >>
-  { Tree.string2Tree("a(b(d,e),c(,f(g,)))").toDotString === "abd..e..c.fg..."
-    Tree.fromDotString("abd..e..c.fg...").show === "a(b(d,e),c(,f(g,)))" }
-
+  methods, `toDotstring` and `fromDotstring`, which do the conversion in both directions""" >> {
+    Tree.fromDotString(".") === End
+    End.toDotString === "."
+    Tree.fromDotString("a..") === Node('a')
+    Node('a').toDotString === "a.."
+    Tree.fromString("a(b(d,e),c(,f(g,)))").toDotString === "abd..e..c.fg..."
+    Tree.fromDotString("abd..e..c.fg...").show === "a(b(d,e),c(,f(g,)))"
+  }
 }

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -218,6 +218,33 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
 
   The tree at right may be constructed with `Tree.fromList(List('n','k','m','c','a','h','g','e','u','p','s','q'))`.
   Use it to check your code""" >> {
+    Tree.fromList(List('n','k','m','c','a','h','g','e','u','p','s','q')).layoutBinaryTree ===
+      PositionedNode('n',
+        PositionedNode('k',
+          PositionedNode('c',
+            PositionedNode('a', End, End, 1, 4),
+            PositionedNode('h',
+              PositionedNode('g',
+                PositionedNode('e', End, End, 3, 6),
+                End,
+                4, 5),
+              End,
+              5, 4),
+            2, 3),
+          PositionedNode('m', End, End, 7, 3),
+          6, 2),
+        PositionedNode('u',
+          PositionedNode('p',
+            End,
+            PositionedNode('s',
+              PositionedNode('q', End, End, 10, 5),
+              End,
+              11, 4),
+            9, 3),
+          End,
+          12, 2),
+        8, 1)
+
     Node(0).layoutBinaryTree.toString === "T[1,1](0 . .)"
     Node(0, Node(1), End).layoutBinaryTree.toString === "T[2,1](0 T[1,2](1 . .) .)"
     Node(0, End, Node(1)).layoutBinaryTree.toString === "T[1,1](0 . T[2,2](1 . .))"
@@ -237,6 +264,27 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
 
   The tree at right may be constructed with `Tree.fromList(List('n','k','m','c','a','e','d','g','u','p','q'))`.
   Use it to check your code""" >> {
+    Tree.fromList(List('n','k','m','c','a','e','d','g','u','p','q')).layoutBinaryTree2 ===
+      PositionedNode('n',
+        PositionedNode('k',
+          PositionedNode('c',
+            PositionedNode('a', End, End, 1, 4),
+            PositionedNode('e',
+              PositionedNode('d', End, End, 4, 5),
+              PositionedNode('g', End, End, 6, 5),
+              5, 4),
+            3, 3),
+          PositionedNode('m', End, End, 11, 3),
+          7, 2),
+        PositionedNode('u',
+          PositionedNode('p',
+            End,
+            PositionedNode('q', End, End, 21, 4),
+            19, 3),
+          End,
+          23, 2),
+        15, 1)
+
     // Note: these test cases may give more hints on the rules of this layout. Don't read them if you
     // want to figure them out on your own
     Node(0).layoutBinaryTree2.toString === "T[1,1](0 . .)"
@@ -261,6 +309,27 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   Note: This is a difficult problem. Don't give up too early!
 
   Which layout do you like most?""" >> {
+    Tree.fromList(List('n','k','m','c','a','e','d','g','u','p','q')).layoutBinaryTree3 ===
+      PositionedNode('n',
+        PositionedNode('k',
+          PositionedNode('c',
+            PositionedNode('a', End, End, 1, 4),
+            PositionedNode('e',
+              PositionedNode('d', End, End, 2, 5),
+              PositionedNode('g', End, End, 4, 5),
+              3, 4),
+            3, 3),
+          PositionedNode('m', End, End, 4, 3),
+          3, 2),
+        PositionedNode('u',
+          PositionedNode('p',
+            End,
+            PositionedNode('q', End, End, 7, 4),
+            6, 3),
+          End,
+          7, 2),
+        5, 1)
+
     // Note: these test cases may give more hints on the rules of this layout. Don't read them if you
     // want to figure them out on your own
     Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -332,14 +332,11 @@ class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
 
     // Note: these test cases may give more hints on the rules of this layout. Don't read them if you
     // want to figure them out on your own
-    Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
-      "T[2,1]('a T[1,2]('b . T[2,3]('c . .)) T[3,2]('d . .))"
-
     Node(0).layoutBinaryTree3.toString === "T[1,1](0 . .)"
     Node(0, Node(1), End).layoutBinaryTree3.toString === "T[2,1](0 T[1,2](1 . .) .)"
     Node(0, End, Node(1)).layoutBinaryTree3.toString === "T[1,1](0 . T[2,2](1 . .))"
     Node('a', Node('b', End, Node('c')), Node('d')).layoutBinaryTree3.toString ===
-      "T[3,1](a T[1,2](b . T[2,3](c . .)) T[5,2](d . .))"
+      "T[2,1](a T[1,2](b . T[2,3](c . .)) T[3,2](d . .))"
     Node(0, Node(1, Node(2, Node(3), End), End), End).layoutBinaryTree3.toString ===
       "T[4,1](0 T[3,2](1 T[2,3](2 T[1,4](3 . .) .) .) .)"
     Node(0, Node(1, Node(2, Node(3), Node(4, Node(5), Node(6))), End), End).layoutBinaryTree3.toString ===

--- a/src/test/scala/s99/BinaryTreesSpec.scala
+++ b/src/test/scala/s99/BinaryTreesSpec.scala
@@ -1,8 +1,7 @@
 package s99
 
-import org.specs2.mutable.Specification
+class BinaryTreesSpec extends S99Specification with BinaryTreesSolutions {
 
-class BinaryTreesSpec extends Specification with BinaryTreesSolutions {
   /*
   A binary tree is either empty or it is composed of a root element and two successors, which are binary trees
   themselves.

--- a/src/test/scala/s99/GraphsSpec.scala
+++ b/src/test/scala/s99/GraphsSpec.scala
@@ -1,8 +1,6 @@
 package s99
 
-import org.specs2.mutable.Specification
-
-class GraphsSpec extends Specification with GraphsSolutions {
+class GraphsSpec extends S99Specification with GraphsSolutions {
 
   /*
   A graph is defined as a set of nodes and a set of edges, where each edge is a pair of nodes.

--- a/src/test/scala/s99/GraphsSpec.scala
+++ b/src/test/scala/s99/GraphsSpec.scala
@@ -4,7 +4,8 @@ import org.specs2.mutable.Specification
 
 class GraphsSpec extends Specification with GraphsSolutions {
 
-  """ A graph is defined as a set of nodes and a set of edges, where each edge is a pair of nodes.
+  /*
+  A graph is defined as a set of nodes and a set of edges, where each edge is a pair of nodes.
 
   The class to represent a graph is mutable, which isn't in keeping with pure functional programming, but a pure
   functional data structure would make things much, much more complicated. [Pure functional graphs with cycles require
@@ -76,7 +77,7 @@ class GraphsSpec extends Specification with GraphsSolutions {
 
   The notation for labeled graphs can also be used for so-called multi-graphs, where more than one edge (or arc) is
   allowed between two given nodes
-  """
+  */
 
   """ Conversions
 

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -212,12 +212,13 @@ class ListsSpec extends Specification with ListsSolutions {
   """P26 Generate the combinations of K distinct objects chosen from the N elements of a list
   In how many ways can a committee of 3 be chosen from a group of 12 people? We all know that there are
   C(12,3) = 220 possibilities (C(N,K) denotes the well-known binomial coefficient). For pure mathematicians, this
-  result may be great But we want to really generate all the possibilities""" >> {
+  result may be great. But we want to really generate all the possibilities""" >> {
     combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)) must contain(List('a, 'b, 'c), List('a, 'b, 'd), List('a, 'b, 'e))
     combinations(0, List(1, 2, 3)) === List(Nil)
-    combinations(1, List(1, 2, 3)) === List(List(1), List(2), List(3))
-    combinations(2, List(1, 2, 3)) === List(List(1, 2), List(1, 3), List(2, 3))
+    combinations(1, List(1, 2, 3)).toSet === Set(List(1), List(2), List(3))
+    combinations(2, List(1, 2, 3)).toSet === Set(List(1, 2), List(1, 3), List(2, 3))
     combinations(3, List(1, 2, 3)) === List(List(1, 2, 3))
+    combinations(4, List(1, 2, 3)) === Nil
   }
 
   """P27 Group the elements of a set into disjoint subsets

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -156,28 +156,57 @@ class ListsSpec extends Specification with ListsSolutions {
 
   "P21 Insert an element at a given position into a list" >> {
     insertAt('new, 1, List('a, 'b, 'c, 'd)) === List('a, 'new, 'b, 'c, 'd)
+    insertAt(1, 0, Nil) === List(1)
+    insertAt(3, 2, List(1, 2)) === List(1, 2, 3)
   }
 
   "P22 Create a list containing all integers within a given range" >> {
     range(4, 9) === List(4, 5, 6, 7, 8, 9)
+    range(0, 0) === List(0)
+    range(2, 1) === Nil
   }
 
   "P23 Extract a given number of randomly selected elements from a list. Hint: Use the solution to problem P20" >> {
-    val selected = randomSelect(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h))
-    selected.size === 3
-    selected.distinct.size === selected.size
+    randomSelect(0, List(1, 2, 3)) === Nil
+
+    (1 to 100).map { _ =>
+      val selected = randomSelect(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h))
+      selected.size === 3
+      selected.distinct.size === selected.size
+      List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) must containAllOf(selected)
+    }
+
+    // with true randomness, this example has 10 * (1/10) ^ 100 = 1e-99 probability of
+    // yielding a false negative. Comment this if you don't want even the small chance
+    // of a test failing when the code is correct
+    (1 to 100).map { _ => randomSelect(1, (1 to 10).toList).head }.toSet.size !== 1
   }
 
   "P24 Lotto: Draw N different random numbers from the set 1..M" >> {
-    val selected = lotto(6, 49)
-    selected.size === 6
-    ((_: Int) must be_<=(49)).forall(selected)
+    for(_ <- 1 to 100) {
+      val selected = lotto(6, 49)
+      selected.size === 6
+      ((_: Int) must beBetween(1, 49)).forall(selected)
+    }
+
+    // with true randomness, this example has 10 * (1/10) ^ 100 = 1e-99 probability of
+    // yielding a false negative. Comment this if you don't want even the small chance
+    // of a test failing when the code is correct
+    (1 to 100).map { _ => lotto(1, 10).head }.toSet.size !== 1
   }
 
   "P25 Generate a random permutation of the elements of a list. Hint: Use the solution of problem P23" >> {
-    val permute = randomPermute(List('a, 'b, 'c, 'd, 'e, 'f))
-    permute.size === 6
-    permute.distinct.size === permute.size
+    for(_ <- 1 to 100) {
+      val permute = randomPermute(List('a, 'b, 'c, 'd, 'e, 'f))
+      permute.size === 6
+      permute.distinct.size === permute.size
+      List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) must containAllOf(permute)
+    }
+
+    // with true randomness, this example has 6 * (1/6) ^ 100 = 9.18e-78 probability of
+    // yielding a false negative. Comment this if you don't want even the small chance
+    // of a test failing when the code is correct
+    (1 to 100).map { _ => randomPermute(List(1, 2, 3)) }.toSet.size !== 1
   }
 
   """P26 Generate the combinations of K distinct objects chosen from the N elements of a list
@@ -185,6 +214,10 @@ class ListsSpec extends Specification with ListsSolutions {
   C(12,3) = 220 possibilities (C(N,K) denotes the well-known binomial coefficient). For pure mathematicians, this
   result may be great But we want to really generate all the possibilities""" >> {
     combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)) must contain(List('a, 'b, 'c), List('a, 'b, 'd), List('a, 'b, 'e))
+    combinations(0, List(1, 2, 3)) === List(Nil)
+    combinations(1, List(1, 2, 3)) === List(List(1), List(2), List(3))
+    combinations(2, List(1, 2, 3)) === List(List(1, 2), List(1, 3), List(2, 3))
+    combinations(3, List(1, 2, 3)) === List(List(1, 2, 3))
   }
 
   """P27 Group the elements of a set into disjoint subsets
@@ -199,14 +232,20 @@ class ListsSpec extends Specification with ListsSolutions {
 
   You may find more about this combinatorial problem in a good book on discrete mathematics under the term
   "multinomial coefficients" """ >> {
-    groups(List(1, 1), List("Aldo", "Beat")) must contain(
-      List(List("Aldo"), List("Beat")))
-
     group3(List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
       List(List("Aldo", "Beat"), List("Carla", "David", "Evi"), List("Flip", "Gary", "Hugo", "Ida")))
 
+    groups(List(1, 1), List("Aldo", "Beat")) must haveTheSameElementsAs(List(
+      List(List("Aldo"), List("Beat")),
+      List(List("Beat"), List("Aldo"))
+    ))
+
     groups(List(2, 2, 5), List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
       List(List("Aldo", "Beat"), List("Carla", "David"), List("Evi", "Flip", "Gary", "Hugo", "Ida")))
+
+    groups(List(3), List(1, 2, 3)) === List(List(List(1, 2, 3)))
+    groups(List(0), Nil) === List(List(Nil))
+    groups(Nil, Nil) === List(Nil)
   }
 
   """P28 Sorting a list of lists according to length of sublists
@@ -218,10 +257,20 @@ class ListsSpec extends Specification with ListsSolutions {
     lsort(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
       List(List('o), List('d, 'e), List('d, 'e), List('m, 'n), List('a, 'b, 'c), List('f, 'g, 'h), List('i, 'j, 'k, 'l))
 
+    lsort(Nil) === Nil
+    lsort(List(Nil)) === List(Nil)
+    lsort(List(List(1, 2, 3), List(1), Nil, List(1, 2))) ===
+      List(Nil, List(1), List(1, 2), List(1, 2, 3))
+
     // Note that in this example, the first two lists in the result have length 4 and 1 and both lengths appear just once.
     // The third and fourth lists have length 3 and there are two list of this length. Finally, the last three lists have
     // length 2. This is the most frequent length.
     lsortFreq(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
       List(List('i, 'j, 'k, 'l), List('o), List('a, 'b, 'c), List('f, 'g, 'h), List('d, 'e), List('d, 'e), List('m, 'n))
+
+    lsortFreq(Nil) === Nil
+    lsortFreq(List(Nil)) === List(Nil)
+    lsortFreq(List(Nil, List(1), List(1, 2), Nil, List(2), List(1, 2, 3), Nil, List(1, 3), List(3), Nil)) ===
+      List(List(1, 2, 3), List(1, 2), List(1, 3), List(1), List(2), List(3), Nil, Nil, Nil, Nil)
   }
 }

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -1,5 +1,6 @@
 package s99
 
+import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
 class ListsSpec extends Specification with ListsSolutions {
@@ -214,7 +215,7 @@ class ListsSpec extends Specification with ListsSolutions {
   C(12,3) = 220 possibilities (C(N,K) denotes the well-known binomial coefficient). For pure mathematicians, this
   result may be great. But we want to really generate all the possibilities""" >> {
     combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)).map(_.toSet) must
-      contain(Set('a, 'b, 'c), Set('a, 'b, 'd), Set('a, 'b, 'e))
+      containElements(Set('a, 'b, 'c), Set('a, 'b, 'd), Set('a, 'b, 'e))
 
     combinations(0, List(1, 2, 3)) === List(Nil)
     combinations(1, List(1, 2, 3)).map(_.toSet).toSet === Set(Set(1), Set(2), Set(3))
@@ -288,4 +289,6 @@ class ListsSpec extends Specification with ListsSolutions {
     lsortFreq(List(Nil, List(1), List(1, 1), Nil, List(1), List(1, 1, 1), Nil, List(1, 1), List(1), Nil)) ===
       List(List(1, 1, 1), List(1, 1), List(1, 1), List(1), List(1), List(1), Nil, Nil, Nil, Nil)
   }
+
+  def containElements[A](elems: A*): Matcher[Traversable[A]] = { (_: Traversable[A]) must contain(allOf(elems: _*)) }
 }

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -1,116 +1,171 @@
 package s99
+
 import org.specs2.mutable._
 
 class ListsSpec extends Specification with ListsSolutions {
 
-  "Find the last element of a list" >>
-  { last(List(1, 1, 2, 3, 5, 8)) === 8 }
+  "P01 Find the last element of a list" >> {
+    last(List(1, 1, 2, 3, 5, 8)) === 8
+  }
 
-  "Find the last but one element of a list" >>
-  { penultimate(List(1, 1, 2, 3, 5, 8)) === 5 }
+  "P02 Find the last but one element of a list" >> {
+    penultimate(List(1, 1, 2, 3, 5, 8)) === 5
+  }
 
-  "Find the nth element of a list. By convention, the first element in the list is element 0" >>
-  { nth(2, List(1, 1, 2, 3, 5, 8)) === 2 }
+  "P03 Find the nth element of a list. By convention, the first element in the list is element 0" >> {
+    nth(2, List(1, 1, 2, 3, 5, 8)) === 2
+  }
 
-  "Find the number of elements of a list" >>
-  { length(List(1, 1, 2, 3, 5, 8)) === 6 }
+  "P04 Find the number of elements of a list" >> {
+    length(List(1, 1, 2, 3, 5, 8)) === 6
+  }
 
-  "Reverse a list" >>
-  { reverse(List(1, 1, 2, 3, 5, 8)) === List(8, 5, 3, 2, 1, 1) }
+  "P05 Reverse a list" >> {
+    reverse(List(1, 1, 2, 3, 5, 8)) === List(8, 5, 3, 2, 1, 1)
+  }
 
-  "Find out whether a list is a palindrome" >>
-  { isPalindrome(List(1, 2, 3, 2, 1)) must beTrue }
+  "P06 Find out whether a list is a palindrome" >> {
+    isPalindrome(List(1, 2, 3, 2, 1)) must beTrue
+    isPalindrome(List(1, 3, 3, 2, 1)) must beFalse
+    isPalindrome(Nil) must beTrue
+    isPalindrome(List(1)) must beTrue
+    isPalindrome(List(5, 5)) must beTrue
+  }
 
-  "Flatten a nested list structure" >>
-  { flatten(List(List(1, 1), 2, List(3, List(5, 8)))) === List(1, 1, 2, 3, 5, 8) }
+  "P07 Flatten a nested list structure" >> {
+    flatten(List(List(1, 1), 2, List(3, List(5, 8)))) === List(1, 1, 2, 3, 5, 8)
+    flatten(Nil) === Nil
+    flatten(List(List('a, List('b, List('c))))) === List('a, 'b, 'c)
+  }
 
-  """ Eliminate consecutive duplicates of list elements
+  """P08 Eliminate consecutive duplicates of list elements
   If a list contains repeated elements they
-  should be replaced with a single copy of the element. The order of the elements should not be changed""" >>
-  { compress(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) === List('a, 'b, 'c, 'a, 'd, 'e) }
+  should be replaced with a single copy of the element. The order of the elements should not be changed""" >> {
+    compress(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) === List('a, 'b, 'c, 'a, 'd, 'e)
+    compress(Nil) === compress(Nil)
+  }
 
-  """ Pack consecutive duplicates of list elements into sublists
-  If a list contains repeated elements they should be placed in separate sublists """ >>
-  { pack(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
-      List(List('a, 'a, 'a, 'a), List('b), List('c, 'c), List('a, 'a), List('d), List('e, 'e, 'e, 'e)) }
+  """P09 Pack consecutive duplicates of list elements into sublists
+  If a list contains repeated elements they should be placed in separate sublists""" >> {
+    pack(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
+      List(List('a, 'a, 'a, 'a), List('b), List('c, 'c), List('a, 'a), List('d), List('e, 'e, 'e, 'e))
+    pack(Nil) === Nil
+    pack(List(1)) === List(List(1))
+  }
 
-  """ Run-length encoding of a list
+  """P10 Run-length encoding of a list
   Use the result of problem P09 to implement the so-called run-length encoding data compression method.
   Consecutive duplicates of elements are encoded as tuples (N, E) where N is the number
-  of duplicates of the element E""" >>
-  { encode(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
-      List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e)) }
+  of duplicates of the element E""" >> {
+    encode(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
+      List((4, 'a), (1, 'b), (2, 'c), (2, 'a), (1, 'd), (4, 'e))
 
-  """ Modified run-length encoding
+    encode(Nil) === Nil
+    encode(List(1)) === List((1, 1))
+  }
+
+  """P11 Modified run-length encoding
   Modify the result of problem P10 in such a way that if an element has no duplicates it is simply copied into the
-  result list. Only elements with duplicates are transferred as (N, E) terms""" >>
-   { encodeModified(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
-      List((4,'a), 'b, (2,'c), (2,'a), 'd, (4,'e)) }
+  result list. Only elements with duplicates are transferred as (N, E) terms""" >> {
+    encodeModified(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
+      List((4, 'a), 'b, (2, 'c), (2, 'a), 'd, (4, 'e))
 
-  """ Decode a run-length encoded list
-  Given a run-length code list generated as specified in problem P10, construct its uncompressed version""" >>
-  { decode(List((4, 'a), (1, 'b), (2, 'c), (2, 'a), (1, 'd), (4, 'e))) ===
-      List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e) }
+    encodeModified(List(1)) === List(1)
+    encodeModified(Nil) === Nil
+    encodeModified(List('a', 'b', 'b', 'c')) === List('a', (2, 'b'), 'c')
+  }
 
-  """ Run-length encoding of a list (direct solution)
+  """P12 Decode a run-length encoded list
+  Given a run-length code list generated as specified in problem P10, construct its uncompressed version""" >> {
+    decode(List((4, 'a), (1, 'b), (2, 'c), (2, 'a), (1, 'd), (4, 'e))) ===
+      List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)
+
+    decode(Nil) === Nil
+    decode(List((1, 1), (2, 2), (3, 3))) === List(1, 2, 2, 3, 3, 3)
+  }
+
+  """P13 Run-length encoding of a list (direct solution)
   Implement the so-called run-length encoding data compression method directly. I.e. don't use other methods you've
-  written (like P09's pack); do all the work directly""" >>
-  { encodeDirect(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
-      List((4,'a), (1,'b), (2,'c), (2,'a), (1,'d), (4,'e)) }
+  written (like P09's pack); do all the work directly""" >> {
+    encodeDirect(List('a, 'a, 'a, 'a, 'b, 'c, 'c, 'a, 'a, 'd, 'e, 'e, 'e, 'e)) ===
+      List((4, 'a), (1, 'b), (2, 'c), (2, 'a), (1, 'd), (4, 'e))
 
-  "Duplicate the elements of a list" >>
-  { duplicate(List('a, 'b, 'c, 'c, 'd)) === List('a, 'a, 'b, 'b, 'c, 'c, 'c, 'c, 'd, 'd) }
+    encodeDirect(Nil) === Nil
+    encodeDirect(List(1)) === List((1, 1))
+  }
 
-  "Duplicate the elements of a list a given number of times" >>
-  { duplicateN(3, List('a, 'b, 'c, 'c, 'd)) === List('a, 'a, 'a, 'b, 'b, 'b, 'c, 'c, 'c, 'c, 'c, 'c, 'd, 'd, 'd) }
+  "P14 Duplicate the elements of a list" >> {
+    duplicate(List('a, 'b, 'c, 'c, 'd)) === List('a, 'a, 'b, 'b, 'c, 'c, 'c, 'c, 'd, 'd)
+    duplicate(Nil) === Nil
+    duplicate(List(1)) === List(1, 1)
+  }
 
-  "Drop every Nth element from a list" >>
-  { drop(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('a, 'b, 'd, 'e, 'g, 'h, 'j, 'k) }
+  "P15 Duplicate the elements of a list a given number of times" >> {
+    duplicateN(3, List('a, 'b, 'c, 'c, 'd)) === List('a, 'a, 'a, 'b, 'b, 'b, 'c, 'c, 'c, 'c, 'c, 'c, 'd, 'd, 'd)
+    duplicateN(3, Nil) === Nil
+    duplicateN(1, Nil) === Nil
+    duplicateN(1, List(1, 2, 3)) === List(1, 2, 3)
+    duplicateN(0, List(1, 2, 3)) === Nil
+  }
 
-  "Split a list into two parts.  The length of the first part is given. Use a Tuple for your result" >>
-  { split(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === (List('a, 'b, 'c),List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) }
+  "P16 Drop every Nth element from a list" >> {
+    drop(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('a, 'b, 'd, 'e, 'g, 'h, 'j, 'k)
+  }
 
-  """ Extract a slice from a list
+  "P17 Split a list into two parts.  The length of the first part is given. Use a Tuple for your result" >> {
+    split(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) ===(List('a, 'b, 'c), List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k))
+  }
+
+  """P18 Extract a slice from a list
   Given two indices, I and K, the slice is the list containing the elements from and including the Ith element up to
-  but not including the Kth element of the original list. Start counting the elements with 0""" >>
-  { slice(3, 7, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g) }
+  but not including the Kth element of the original list. Start counting the elements with 0""" >> {
+    slice(3, 7, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g)
+  }
 
-  "Rotate a list N places to the left" >>
-  { rotate(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'a, 'b, 'c)
-    rotate(-2, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('j, 'k, 'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) }
+  "P19 Rotate a list N places to the left" >> {
+    rotate(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'a, 'b, 'c)
+    rotate(-2, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('j, 'k, 'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i)
+  }
 
-  """ Remove the Kth element from a list
-  Return the list and the removed element in a Tuple. Elements are numbered from 0""" >>
-  { removeAt(1, List('a, 'b, 'c, 'd)) === (List('a, 'c, 'd),'b) }
+  """P20 Remove the Kth element from a list
+  Return the list and the removed element in a Tuple. Elements are numbered from 0""" >> {
+    removeAt(1, List('a, 'b, 'c, 'd)) ===(List('a, 'c, 'd), 'b)
+  }
 
-  "Insert an element at a given position into a list" >>
-  { insertAt('new, 1, List('a, 'b, 'c, 'd)) === List('a, 'new, 'b, 'c, 'd) }
+  "P21 Insert an element at a given position into a list" >> {
+    insertAt('new, 1, List('a, 'b, 'c, 'd)) === List('a, 'new, 'b, 'c, 'd)
+  }
 
-  "Create a list containing all integers within a given range" >>
-  { range(4, 9) === List(4, 5, 6, 7, 8, 9) }
+  "P22 Create a list containing all integers within a given range" >> {
+    range(4, 9) === List(4, 5, 6, 7, 8, 9)
+  }
 
-  "Extract a given number of randomly selected elements from a list. Hint: Use the solution to problem P20" >>
-  { val selected = randomSelect(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h))
+  "P23 Extract a given number of randomly selected elements from a list. Hint: Use the solution to problem P20" >> {
+    val selected = randomSelect(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h))
     selected.size === 3
-    selected.distinct.size === selected.size }
+    selected.distinct.size === selected.size
+  }
 
-  "Lotto: Draw N different random numbers from the set 1..M" >>
-  { val selected = lotto(6, 49)
+  "P24 Lotto: Draw N different random numbers from the set 1..M" >> {
+    val selected = lotto(6, 49)
     selected.size === 6
-    ((_: Int) must be_<=(49)).forall(selected) }
+    ((_: Int) must be_<=(49)).forall(selected)
+  }
 
-  "Generate a random permutation of the elements of a list. Hint: Use the solution of problem P23" >>
-  { val permute = randomPermute(List('a, 'b, 'c, 'd, 'e, 'f))
+  "P25 Generate a random permutation of the elements of a list. Hint: Use the solution of problem P23" >> {
+    val permute = randomPermute(List('a, 'b, 'c, 'd, 'e, 'f))
     permute.size === 6
-    permute.distinct.size === permute.size }
+    permute.distinct.size === permute.size
+  }
 
-  """ Generate the combinations of K distinct objects chosen from the N elements of a list
+  """P26 Generate the combinations of K distinct objects chosen from the N elements of a list
   In how many ways can a committee of 3 be chosen from a group of 12 people? We all know that there are
   C(12,3) = 220 possibilities (C(N,K) denotes the well-known binomial coefficient). For pure mathematicians, this
-  result may be great But we want to really generate all the possibilities""" >>
-  { combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)) must contain(List('a, 'b, 'c), List('a, 'b, 'd), List('a, 'b, 'e)) }
+  result may be great But we want to really generate all the possibilities""" >> {
+    combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)) must contain(List('a, 'b, 'c), List('a, 'b, 'd), List('a, 'b, 'e))
+  }
 
-  """ Group the elements of a set into disjoint subsets
+  """P27 Group the elements of a set into disjoint subsets
    a) In how many ways can a group of 9 people work in 3 disjoint subgroups of 2, 3 and 4 persons?
       Write a function that generates all the possibilities.
    b) Generalize the above predicate in a way that we can specify a list of group sizes and the predicate
@@ -121,29 +176,30 @@ class ListsSpec extends Specification with ListsSolutions {
    ((Carla, David), (Aldo, Beat), ...).
 
   You may find more about this combinatorial problem in a good book on discrete mathematics under the term
-  "multinomial coefficients" """ >>
-  {
-    groups(List(1, 1), List("Aldo", "Beat")) must contain (
+  "multinomial coefficients" """ >> {
+    groups(List(1, 1), List("Aldo", "Beat")) must contain(
       List(List("Aldo"), List("Beat")))
 
-    group3(List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain (
+    group3(List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
       List(List("Aldo", "Beat"), List("Carla", "David", "Evi"), List("Flip", "Gary", "Hugo", "Ida")))
 
     groups(List(2, 2, 5), List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
-      List(List("Aldo", "Beat"), List("Carla", "David"), List("Evi", "Flip", "Gary", "Hugo", "Ida"))) }
+      List(List("Aldo", "Beat"), List("Carla", "David"), List("Evi", "Flip", "Gary", "Hugo", "Ida")))
+  }
 
-  """ Sorting a list of lists according to length of sublists
+  """P28 Sorting a list of lists according to length of sublists
     a) We suppose that a list contains elements that are lists themselves. The objective is to sort the elements
        of the list according to their length. E.g. short lists first, longer lists later, or vice versa.
     b) Again, we suppose that a list contains elements that are lists themselves. But this time the objective is
        to sort the elements according to their length frequency; i.e. in the default, sorting is done ascendingly,
-       lists with rare lengths are placed, others with a more frequent length come later""" >>
-  { lsort(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
+       lists with rare lengths are placed, others with a more frequent length come later""" >> {
+    lsort(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
       List(List('o), List('d, 'e), List('d, 'e), List('m, 'n), List('a, 'b, 'c), List('f, 'g, 'h), List('i, 'j, 'k, 'l))
 
-     // Note that in this example, the first two lists in the result have length 4 and 1 and both lengths appear just once.
-     // The third and fourth lists have length 3 and there are two list of this length. Finally, the last three lists have
-     // length 2. This is the most frequent length.
-     lsortFreq(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
-       List(List('i, 'j, 'k, 'l), List('o), List('a, 'b, 'c), List('f, 'g, 'h), List('d, 'e), List('d, 'e), List('m, 'n)) }
+    // Note that in this example, the first two lists in the result have length 4 and 1 and both lengths appear just once.
+    // The third and fourth lists have length 3 and there are two list of this length. Finally, the last three lists have
+    // length 2. This is the most frequent length.
+    lsortFreq(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
+      List(List('i, 'j, 'k, 'l), List('o), List('a, 'b, 'c), List('f, 'g, 'h), List('d, 'e), List('d, 'e), List('m, 'n))
+  }
 }

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -169,7 +169,7 @@ class ListsSpec extends Specification with ListsSolutions {
   "P23 Extract a given number of randomly selected elements from a list. Hint: Use the solution to problem P20" >> {
     randomSelect(0, List(1, 2, 3)) === Nil
 
-    (1 to 100).map { _ =>
+    for(_ <- 1 to 100) {
       val selected = randomSelect(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h))
       selected.size === 3
       selected.distinct.size === selected.size
@@ -213,11 +213,13 @@ class ListsSpec extends Specification with ListsSolutions {
   In how many ways can a committee of 3 be chosen from a group of 12 people? We all know that there are
   C(12,3) = 220 possibilities (C(N,K) denotes the well-known binomial coefficient). For pure mathematicians, this
   result may be great. But we want to really generate all the possibilities""" >> {
-    combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)) must contain(List('a, 'b, 'c), List('a, 'b, 'd), List('a, 'b, 'e))
+    combinations(3, List('a, 'b, 'c, 'd, 'e, 'f)).map(_.toSet) must
+      contain(Set('a, 'b, 'c), Set('a, 'b, 'd), Set('a, 'b, 'e))
+
     combinations(0, List(1, 2, 3)) === List(Nil)
-    combinations(1, List(1, 2, 3)).toSet === Set(List(1), List(2), List(3))
-    combinations(2, List(1, 2, 3)).toSet === Set(List(1, 2), List(1, 3), List(2, 3))
-    combinations(3, List(1, 2, 3)) === List(List(1, 2, 3))
+    combinations(1, List(1, 2, 3)).map(_.toSet).toSet === Set(Set(1), Set(2), Set(3))
+    combinations(2, List(1, 2, 3)).map(_.toSet).toSet === Set(Set(1, 2), Set(1, 3), Set(2, 3))
+    combinations(3, List(1, 2, 3)).map(_.toSet).toSet === Set(Set(1, 2, 3))
     combinations(4, List(1, 2, 3)) === Nil
   }
 
@@ -233,18 +235,21 @@ class ListsSpec extends Specification with ListsSolutions {
 
   You may find more about this combinatorial problem in a good book on discrete mathematics under the term
   "multinomial coefficients" """ >> {
-    group3(List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
-      List(List("Aldo", "Beat"), List("Carla", "David", "Evi"), List("Flip", "Gary", "Hugo", "Ida")))
+    group3(List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")).map(_.map(_.toSet)) must
+      contain(List(Set("Aldo", "Beat"), Set("Carla", "David", "Evi"), Set("Flip", "Gary", "Hugo", "Ida")))
 
-    groups(List(1, 1), List("Aldo", "Beat")) must haveTheSameElementsAs(List(
+    groups(List(1, 1), List("Aldo", "Beat")).toSet === Set(
       List(List("Aldo"), List("Beat")),
       List(List("Beat"), List("Aldo"))
-    ))
+    )
 
-    groups(List(2, 2, 5), List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")) must contain(
-      List(List("Aldo", "Beat"), List("Carla", "David"), List("Evi", "Flip", "Gary", "Hugo", "Ida")))
+    groups(List(2, 3, 4), List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")).map(_.map(_.toSet)) must
+      contain(List(Set("Aldo", "Beat"), Set("Carla", "David", "Evi"), Set("Flip", "Gary", "Hugo", "Ida")))
 
-    groups(List(3), List(1, 2, 3)) === List(List(List(1, 2, 3)))
+    groups(List(2, 2, 5), List("Aldo", "Beat", "Carla", "David", "Evi", "Flip", "Gary", "Hugo", "Ida")).map(_.map(_.toSet)) must
+      contain(List(Set("Aldo", "Beat"), Set("Carla", "David"), Set("Evi", "Flip", "Gary", "Hugo", "Ida")))
+
+    groups(List(3), List(1, 2, 3)).map(_.map(_.toSet)) === List(List(Set(1, 2, 3)))
     groups(List(0), Nil) === List(List(Nil))
     groups(Nil, Nil) === List(Nil)
   }
@@ -255,8 +260,13 @@ class ListsSpec extends Specification with ListsSolutions {
     b) Again, we suppose that a list contains elements that are lists themselves. But this time the objective is
        to sort the elements according to their length frequency; i.e. in the default, sorting is done ascendingly,
        lists with rare lengths are placed, others with a more frequent length come later""" >> {
-    lsort(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
-      List(List('o), List('d, 'e), List('d, 'e), List('m, 'n), List('a, 'b, 'c), List('f, 'g, 'h), List('i, 'j, 'k, 'l))
+    val sorted = lsort(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e),
+      List('i, 'j, 'k, 'l), List('m, 'n), List('o)))
+
+    sorted(0) === List('o)
+    sorted.slice(1, 4).toSet === Set(List('d, 'e), List('d, 'e), List('m, 'n))
+    sorted.slice(4, 6).toSet === Set(List('a, 'b, 'c), List('f, 'g, 'h))
+    sorted(6) === List('i, 'j, 'k, 'l)
 
     lsort(Nil) === Nil
     lsort(List(Nil)) === List(Nil)
@@ -266,12 +276,16 @@ class ListsSpec extends Specification with ListsSolutions {
     // Note that in this example, the first two lists in the result have length 4 and 1 and both lengths appear just once.
     // The third and fourth lists have length 3 and there are two list of this length. Finally, the last three lists have
     // length 2. This is the most frequent length.
-    lsortFreq(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e), List('i, 'j, 'k, 'l), List('m, 'n), List('o))) ===
-      List(List('i, 'j, 'k, 'l), List('o), List('a, 'b, 'c), List('f, 'g, 'h), List('d, 'e), List('d, 'e), List('m, 'n))
+    val sortedFreq = lsortFreq(List(List('a, 'b, 'c), List('d, 'e), List('f, 'g, 'h), List('d, 'e),
+      List('i, 'j, 'k, 'l), List('m, 'n), List('o)))
+
+    sortedFreq.slice(0, 2).toSet === Set(List('i, 'j, 'k, 'l), List('o))
+    sortedFreq.slice(2, 4).toSet === Set(List('a, 'b, 'c), List('f, 'g, 'h))
+    sortedFreq.slice(4, 7).toSet === Set(List('d, 'e), List('d, 'e), List('m, 'n))
 
     lsortFreq(Nil) === Nil
     lsortFreq(List(Nil)) === List(Nil)
-    lsortFreq(List(Nil, List(1), List(1, 2), Nil, List(2), List(1, 2, 3), Nil, List(1, 3), List(3), Nil)) ===
-      List(List(1, 2, 3), List(1, 2), List(1, 3), List(1), List(2), List(3), Nil, Nil, Nil, Nil)
+    lsortFreq(List(Nil, List(1), List(1, 1), Nil, List(1), List(1, 1, 1), Nil, List(1, 1), List(1), Nil)) ===
+      List(List(1, 1, 1), List(1, 1), List(1, 1), List(1), List(1), List(1), Nil, Nil, Nil, Nil)
   }
 }

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -110,26 +110,48 @@ class ListsSpec extends Specification with ListsSolutions {
 
   "P16 Drop every Nth element from a list" >> {
     drop(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('a, 'b, 'd, 'e, 'g, 'h, 'j, 'k)
+    drop(3, List(1, 2)) === List(1, 2)
+    drop(1, List(4, 5, 6, 7)) === Nil
+    drop(3, Nil) === Nil
   }
 
-  "P17 Split a list into two parts.  The length of the first part is given. Use a Tuple for your result" >> {
+  "P17 Split a list into two parts. The length of the first part is given. Use a Tuple for your result" >> {
     split(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) ===(List('a, 'b, 'c), List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k))
+    split(1, List(1, 2, 3)) === (List(1), List(2, 3))
+    split(0, List('a, 'b)) === (Nil, List('a, 'b))
+    split(0, Nil) === (Nil, Nil)
   }
 
   """P18 Extract a slice from a list
   Given two indices, I and K, the slice is the list containing the elements from and including the Ith element up to
   but not including the Kth element of the original list. Start counting the elements with 0""" >> {
     slice(3, 7, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g)
+    slice(0, 1, List(1, 2, 3, 4)) === List(1)
+    slice(1, 1, List(1, 2, 3, 4)) === Nil
+    slice(0, 3, List('a, 'b, 'c)) === List('a, 'b, 'c)
   }
 
   "P19 Rotate a list N places to the left" >> {
     rotate(3, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('d, 'e, 'f, 'g, 'h, 'i, 'j, 'k, 'a, 'b, 'c)
     rotate(-2, List('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j, 'k)) === List('j, 'k, 'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i)
+    rotate(0, List(2, 3, 4, 5)) === List(2, 3, 4, 5)
+    rotate(4, List(2, 3, 4, 5)) === List(2, 3, 4, 5)
+    rotate(-4, List(2, 3, 4, 5)) === List(2, 3, 4, 5)
+    rotate(0, Nil) === Nil
+
+    // depending on the interpretation of the problem, these examples may or may not be valid
+    rotate(3, Nil) === Nil
+    rotate(7, List(2, 3, 4, 5)) === List(5, 2, 3, 4)
+    rotate(-7, List(2, 3, 4, 5)) === List(3, 4, 5, 2)
+    rotate(10, List(0, 1)) === List(0, 1)
+    rotate(11, List(0, 1)) === List(1, 0)
   }
 
   """P20 Remove the Kth element from a list
   Return the list and the removed element in a Tuple. Elements are numbered from 0""" >> {
-    removeAt(1, List('a, 'b, 'c, 'd)) ===(List('a, 'c, 'd), 'b)
+    removeAt(1, List('a, 'b, 'c, 'd)) === (List('a, 'c, 'd), 'b)
+    removeAt(0, List(1)) === (Nil, 1)
+    removeAt(2, List(1, 2, 3)) === (List(1, 2), 3)
   }
 
   "P21 Insert an element at a given position into a list" >> {

--- a/src/test/scala/s99/ListsSpec.scala
+++ b/src/test/scala/s99/ListsSpec.scala
@@ -3,7 +3,7 @@ package s99
 import org.specs2.matcher.Matcher
 import org.specs2.mutable._
 
-class ListsSpec extends Specification with ListsSolutions {
+class ListsSpec extends S99Specification with ListsSolutions {
 
   "P01 Find the last element of a list" >> {
     last(List(1, 1, 2, 3, 5, 8)) === 8

--- a/src/test/scala/s99/LogicAndCodesSpec.scala
+++ b/src/test/scala/s99/LogicAndCodesSpec.scala
@@ -1,10 +1,10 @@
 package s99
 
-import org.specs2.mutable.Specification
 import org.specs2.matcher._
 import org.specs2.execute.Result
 
-class LogicAndCodesSpec extends Specification with LogicAndCodesSolutions with DataTables {
+class LogicAndCodesSpec extends S99Specification with LogicAndCodesSolutions with DataTables {
+
   """P46 Truth tables for logical expressions
 
   Define functions and, or, nand, nor, xor, impl, and equ for logical equivalence) which return true or false
@@ -113,4 +113,3 @@ class LogicAndCodesSpec extends Specification with LogicAndCodesSolutions with D
   // this specs2 implicit method is deactivated to allow the local definition of Boolean operators
   override def toResult(b: Boolean): Result = super.toResult(b)
 }
-

--- a/src/test/scala/s99/LogicAndCodesSpec.scala
+++ b/src/test/scala/s99/LogicAndCodesSpec.scala
@@ -6,28 +6,17 @@ import org.specs2.execute.Result
 
 
 class LogicAndCodesSpec extends Specification with LogicAndCodesSolutions with DataTables {
-  """ Truth tables for logical expressions
+  """P46 Truth tables for logical expressions
 
   Define functions and, or, nand, nor, xor, impl, and equ for logical equivalence) which return true or false
   according to the result of their respective operations; e.g. and(A, B) is true if and only if both A and B are true
 
-  scala> and(true, true)
-  res0: Boolean = true
-
-  scala> xor(true. true)
-  res1: Boolean = false
   A logical expression in two variables can then be written as an function of two variables, e.g:
   (a: Boolean, b: Boolean) => and(or(a, b), nand(a, b))
 
-  Now, write a function called table2 which prints the truth table of a given logical expression in two variables.
+  Now, write a function called table2 which prints the truth table of a given logical expression in two variables.""" >> {
 
-  scala> table2((a: Boolean, b: Boolean) => and(a, or(a, b)))
-  A     B     result
-  true  true  true
-  true  false true
-  false true  false
-  false false false""" >>
-  { "a" | "b" | "and(a, b)" |>
+    "a" | "b" | "and(a, b)" |>
      T  ! T   ! T           |
      T  ! F   ! F           |
      F  ! T   ! F           |
@@ -74,31 +63,47 @@ class LogicAndCodesSpec extends Specification with LogicAndCodesSolutions with D
           "true  true  true  ",
           "true  false true  ",
           "false true  false ",
-          "false false false ").mkString("\n") }
+          "false false false ").mkString("\n")
 
-  """ Truth tables for logical expressions (2)
+    table2((a: Boolean, b: Boolean) => and(impl(a, b), impl(b, a))) ===
+      Seq("A     B     result",
+          "true  true  true  ",
+          "true  false false ",
+          "false true  false ",
+          "false false true  ").mkString("\n")
+  }
+
+  """P47 Truth tables for logical expressions (2)
 
   Continue problem P46 by redefining and, or, etc as operators. (i.e. make them methods of a new class with an
-  implicit conversion from Boolean.) not will have to be left as a object method.
+  implicit conversion from Boolean). not will have to be left as a object method.""" >> {
 
-  scala> table2((a: Boolean, b: Boolean) => a and (a or not(b)))
-  A     B     result
-  true  true  true
-  true  false true
-  false true  false
-  false false false
-  """ >>
-  { table2((a: Boolean, b: Boolean) => a and (a or not(b))) ===
-    Seq("A     B     result",
-        "true  true  true  ",
-        "true  false true  ",
-        "false true  false ",
-        "false false false ").mkString("\n") }
+    "a" | "not(a)" |>
+     T  ! T        |
+     T  ! F        |
+     F  ! T        |
+     F  ! F        | { not(_) === _ }
 
-  """ Truth tables for logical expressions (3). Omitted for now""" >>
-  { pending }
+    table2((a: Boolean, b: Boolean) => a and (a or not(b))) ===
+      Seq("A     B     result",
+          "true  true  true  ",
+          "true  false true  ",
+          "false true  false ",
+          "false false false ").mkString("\n")
 
-  """ Gray code
+    table2((a: Boolean, b: Boolean) => (a impl b) and (b impl a)) ===
+      Seq("A     B     result",
+          "true  true  true  ",
+          "true  false false ",
+          "false true  false ",
+          "false false true  ").mkString("\n")
+  }
+
+  """P48 Truth tables for logical expressions (3). Omitted for now""" >> {
+    pending
+  }
+
+  """P49 Gray code
 
   An n-bit Gray code is a sequence of n-bit strings constructed according to certain rules. For example,
 
@@ -107,23 +112,35 @@ class LogicAndCodesSpec extends Specification with LogicAndCodesSolutions with D
   n = 3: C(3) = ("000", "001", "011", "010", "110", "111", "101", "100").
 
   Find out the construction rules and write a function to generate Gray codes.
+  See if you can use memoization to make the function more efficient""" >> {
 
-    scala> gray(3)
-    res0 List[String] = List(000, 001, 011, 010, 110, 111, 101, 100)
+    gray(1) === List("0", "1")
+    gray(2) === List("00", "01", "11", "10")
+    gray(3) === List("000", "001", "011", "010", "110", "111", "101", "100")
+    gray(4) === List("0000", "0001", "0011", "0010", "0110", "0111", "0101",
+      "0100", "1100", "1101", "1111", "1110", "1010", "1011", "1001", "1000")
+  }
 
-    See if you can use memoization to make the function more efficient""" >>
-  { gray(3) === List("000", "001", "011", "010", "110", "111", "101", "100") }
-
-  """ Huffman code
+  """P50 Huffman code
 
   First of all, consult a good book on discrete mathematics or algorithms for a detailed description of Huffman
   codes! We suppose a set of symbols with their frequencies, given as a list of (S, F) Tuples.
   E.g. (("a", 45), ("b", 13), ("c", 12), ("d", 16), ("e", 9), ("f", 5)). Our objective is to construct a
-  list of (S, C) Tuples, where C is the Huffman code word for the symbol S""" >>
-  { huffman(List(("a", 45), ("b", 13), ("c", 12), ("d", 16), ("e", 9), ("f", 5))) ===
-         List(("a", 0), ("b", 101), ("c", 100), ("d", 111), ("e", 1101), ("f", 1100)) }
+  list of (S, C) Tuples, where C is the Huffman code word for the symbol S""" >> {
 
-  val T = true; val F = false
+    huffman(List(("a", 45), ("b", 13), ("c", 12), ("d", 16), ("e", 9), ("f", 5))) ===
+      List(("a", "0"), ("b", "101"), ("c", "100"), ("d", "111"), ("e", "1101"), ("f", "1100"))
+
+    huffman(List(("a", 1), ("b", 2))) === List(("a", "0"), ("b", "1"))
+    huffman(List(("a", 2), ("b", 1))) === List(("b", "0"), ("a", "1"))
+
+    huffman(List(("a", 24), ("b", 12), ("c", 10), ("d", 8), ("e", 7))) ===
+      List(("a", "0"), ("b", "111"), ("c", "110"), ("d", "101"), ("e", "100"))
+  }
+
+  val T = true
+  val F = false
+
   // this specs2 implicit method is deactivated to allow the local definition of Boolean operators
   override def toResult(b: Boolean): Result = super.toResult(b)
 }

--- a/src/test/scala/s99/MultiwayTreesSpec.scala
+++ b/src/test/scala/s99/MultiwayTreesSpec.scala
@@ -1,8 +1,7 @@
 package s99
 
-import org.specs2.mutable.Specification
+class MultiwayTreesSpec extends S99Specification with MultiwayTreesSolutions {
 
-class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
   /*
   A multiway tree is composed of a root element and a (possibly empty) set of successors which are multiway trees
   themselves. A multiway tree is never empty. The set of successor trees is sometimes called a forest.

--- a/src/test/scala/s99/MultiwayTreesSpec.scala
+++ b/src/test/scala/s99/MultiwayTreesSpec.scala
@@ -48,6 +48,12 @@ class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
     MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).show === "afg^^c^^"
     MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e'))))).show ===
      "afg^^c^bd^e^^^"
+
+    string2MTree("a^") === MTree('a')
+    string2MTree("af^^") === MTree('a', List(MTree('f')))
+    string2MTree("afg^^c^^") === MTree('a', List(MTree('f', List(MTree('g'))), MTree('c')))
+    string2MTree("afg^^c^bd^e^^^") ===
+      MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e')))))
   }
 
   """P71 Determine the internal path length of a tree

--- a/src/test/scala/s99/MultiwayTreesSpec.scala
+++ b/src/test/scala/s99/MultiwayTreesSpec.scala
@@ -3,8 +3,8 @@ package s99
 import org.specs2.mutable.Specification
 
 class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
-
-  """ A multiway tree is composed of a root element and a (possibly empty) set of successors which are multiway trees
+  /*
+  A multiway tree is composed of a root element and a (possibly empty) set of successors which are multiway trees
   themselves. A multiway tree is never empty. The set of successor trees is sometimes called a forest.
 
   The code to represent these is somewhat simpler than the code for binary trees, partly because we don't separate
@@ -23,13 +23,17 @@ class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
   The example tree is, thus:
 
        MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e')))))
-  """
+  */
 
-  """ Count the nodes of a multiway tree
-  Write a method nodeCount which counts the nodes of a given multiway tree""" >>
-  { MTree('a', List(MTree('f'))).nodeCount === 2 }
+  """P70C Count the nodes of a multiway tree
+  Write a method nodeCount which counts the nodes of a given multiway tree""" >> {
+    MTree('a').nodeCount === 1
+    MTree('a', List(MTree('f'))).nodeCount === 2
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).nodeCount === 4
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e'))))).nodeCount === 7
+  }
 
-  """ Tree construction from a node string
+  """P70 Tree construction from a node string
 
   We suppose that the nodes of a multiway tree contain single characters. In the depth-first order sequence of its
   nodes, a special character ^ has been inserted whenever, during the tree traversal, the move is a backtrack to the
@@ -38,24 +42,38 @@ class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
        afg^^c^bd^e^^^
 
   Define the syntax of the string and write a function string2MTree to construct an MTree from a String. Make the
-  function an implicit conversion from String. Write the reverse function, and make it the `show` method of MTree""" >>
-  { MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e'))))).show ===
-     "afg^^c^bd^e^^^" }
+  function an implicit conversion from String. Write the reverse function, and make it the `show` method of MTree""" >> {
+    MTree('a').show === "a^"
+    MTree('a', List(MTree('f'))).show === "af^^"
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).show === "afg^^c^^"
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e'))))).show ===
+     "afg^^c^bd^e^^^"
+  }
 
-  """ Determine the internal path length of a tree
+  """P71 Determine the internal path length of a tree
 
   We define the internal path length of a multiway tree as the total sum of the path lengths from the root to all
   nodes of the tree. By this definition, the tree in the figure of problem P70 has an internal path length of 9.
-  Write a method internalPathLength to return that sum""" >>
-  { "afg^^c^bd^e^^^".internalPathLength === 9 }
+  Write a method internalPathLength to return that sum""" >> {
+    MTree('a').internalPathLength === 0
+    MTree('a', List(MTree('f'))).internalPathLength === 1
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).internalPathLength === 4
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e')))))
+      .internalPathLength === 9
+  }
 
-  """ Construct the postorder sequence of the tree nodes
+  """P72 Construct the postorder sequence of the tree nodes
 
    Write a method postorder which constructs the postorder sequence of the nodes of a multiway tree. The result should
-   be a List""" >>
-   { "afg^^c^bd^e^^^".postorder === List('g', 'f', 'c', 'd', 'e', 'b', 'a') }
+   be a List""" >> {
+    MTree('a').postOrder === List('a')
+    MTree('a', List(MTree('f'))).postOrder === List('f', 'a')
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).postOrder === List('g', 'f', 'c', 'a')
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e')))))
+      .postOrder === List('g', 'f', 'c', 'd', 'e', 'b', 'a')
+  }
 
-  """ Lisp-like tree representation
+  """P73 Lisp-like tree representation
 
   There is a particular notation for multiway trees in Lisp. Lisp is a prominent functional programming language.
   In Lisp almost everything is a list. Our example tree would be represented in Lisp as (a (f g) c (b d e)). The
@@ -71,7 +89,17 @@ class MultiwayTreesSpec extends Specification with MultiwayTreesSolutions {
 
   [Note: Much of this problem is taken from the wording of the same problem in the Prolog set. This is certainly one
    way of looking at Lisp notation, but it's not how the language actually represents that syntax internally. I can
-   elaborate more on this, if requested""" >>
-  { MTree("a", List(MTree("b", List(MTree("c"))))).lispyTree === "(a (b c))" }
+   elaborate more on this, if requested""" >> {
+    MTree('a').lispyTree === "a"
+    MTree('a', List(MTree('f'))).lispyTree === "(a f)"
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'))).lispyTree === "(a (f g) c)"
+    MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e'))))).lispyTree ===
+      "(a (f g) c (b d e))"
 
+    MTree.fromLispyTree("a") === MTree('a')
+    MTree.fromLispyTree("(a f)") === MTree('a', List(MTree('f')))
+    MTree.fromLispyTree("(a (f g) c)") === MTree('a', List(MTree('f', List(MTree('g'))), MTree('c')))
+    MTree.fromLispyTree("(a (f g) c (b d e))") ===
+      MTree('a', List(MTree('f', List(MTree('g'))), MTree('c'), MTree('b', List(MTree('d'), MTree('e')))))
+  }
 }

--- a/src/test/scala/s99/S99Specification.scala
+++ b/src/test/scala/s99/S99Specification.scala
@@ -1,0 +1,13 @@
+package s99
+
+import org.specs2.execute._
+import org.specs2.mutable.Specification
+import org.specs2.specification.AroundEach
+
+trait S99Specification extends Specification with AroundEach {
+
+  def around[R: AsResult](r: => R): Result = AsResult(r) match {
+    case Failure("an implementation is missing", _, _, _) => Pending("TODO")
+    case res => res
+  }
+}


### PR DESCRIPTION
As I am solving these problems, I'm adding more examples to the specs of each problem, in order to better cover the corner cases. I think they are useful for the people starting this now. For now I only have improved specs for Lists and Arithmetic, but I expect to continuously solve the problems in the next one or two months or so.

Every time I thought the behavior wasn't defined in the problem statement (e.g. get the 3rd element of a two-element list), I simply refrained from adding any test at all. Even so, every time I made a test that could possibly be misinterpreted or described a behavior that was't clear in the original problem statement, I added a comment in-place.

Also updated Scala version and dependencies to Scala 2.10 because I was having trouble with the original dependencies. If you want me to submit a pull request with 2.9.2 it's ok. Also added the code of each problem at the beginning of each description just for style preference, but I can also remove them if you don't like.
